### PR TITLE
Cloning injectors with registered services

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,37 @@ injector := do.NewWithOpts(&do.InjectorOpts{
 })
 ```
 
+### Cloning injector
+
+Cloned injector have same service registrations as it's parent, but it doesn't share invoked service state.
+Clones are useful for unit testing by replacing some services to mocks.
+
+```go
+var injector *do.Injector;
+
+func init() {
+    do.Provide[Service](injector, func (i *do.Injector) (Service, error) {
+        return &RealService{}, nil
+    })
+    do.Provide[*App](injector, func (i *do.Injector) (*App, error) {
+        return &App{i.MustInvoke[Service](i)}, nil
+    })
+}
+
+func TestService(t *testing.T) {
+    i := injector.Clone()
+    defer i.Shutdown()
+
+    // replace Service to MockService
+    do.Provide[Service](i, func (i *do.Injector) (Service, error) {
+        return &MockService{}, nil
+    }))
+
+    app := do.Invoke[*App](i)
+    // do unit testing with mocked service
+}
+```
+
 ## 🛩 Benchmark
 
 // @TODO

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I love **short name** for such utility library. This name is the sum of `DI` and
 - Eagerly or lazily loaded services
 - Dependency graph resolution
 - Default injector
-- Container cloning
+- Injector cloning
 - Service override
 
 🚀 Services are loaded in invocation order.
@@ -356,6 +356,20 @@ config := do.MustInvokeNamed[Config](injector, "configuration")
 do.MustShutdownNamed(injector, "configuration")
 ```
 
+### Service override
+
+By default, providing a service twice will panic. Service can be replaced at runtime using `do.Replace****` helpers.
+
+```go
+do.Provide[Vehicle](injector, func (i *do.Injector) (Vehicle, error) {
+    return &CarImplem{}, nil
+})
+
+do.Override[Vehicle](injector, func (i *do.Injector) (Vehicle, error) {
+    return &BusImplem{}, nil
+})
+```
+
 ### Hooks
 
 3 lifecycle hooks are available in Injectors:
@@ -376,6 +390,7 @@ injector := do.NewWithOpts(&do.InjectorOpts{
 ### Cloning injector
 
 Cloned injector have same service registrations as it's parent, but it doesn't share invoked service state.
+
 Clones are useful for unit testing by replacing some services to mocks.
 
 ```go
@@ -395,7 +410,7 @@ func TestService(t *testing.T) {
     defer i.Shutdown()
 
     // replace Service to MockService
-    do.Provide[Service](i, func (i *do.Injector) (Service, error) {
+    do.Override[Service](i, func (i *do.Injector) (Service, error) {
         return &MockService{}, nil
     }))
 

--- a/injector.go
+++ b/injector.go
@@ -248,7 +248,7 @@ func (i *Injector) CloneWithOpts(opts *InjectorOpts) *Injector {
 	defer i.mu.RUnlock()
 
 	for name, serviceAny := range i.services {
-		if service, ok := serviceAny.(cloeneableService); ok {
+		if service, ok := serviceAny.(cloneableService); ok {
 			clone.services[name] = service.clone()
 		} else {
 			clone.services[name] = service

--- a/injector.go
+++ b/injector.go
@@ -234,3 +234,27 @@ func (i *Injector) onServiceShutdown(name string) {
 		i.hookAfterShutdown(i, name)
 	}
 }
+
+// Clone clones injector with provided services but not with invoked instances.
+func (i *Injector) Clone() *Injector {
+	return i.CloneWithOpts(&InjectorOpts{})
+}
+
+// CloneWithOpts clones injector with provided services but not with invoked instances, with options.
+func (i *Injector) CloneWithOpts(opts *InjectorOpts) *Injector {
+	clone := NewWithOpts(opts)
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	for name, serviceAny := range i.services {
+		if service, ok := serviceAny.(cloeneableService); ok {
+			clone.services[name] = service.clone()
+		} else {
+			clone.services[name] = service
+		}
+		defer clone.onServiceRegistration(name)
+	}
+
+	return clone
+}

--- a/injector_test.go
+++ b/injector_test.go
@@ -290,7 +290,10 @@ func TestInjectorClone(t *testing.T) {
 		count++
 		return 42, nil
 	})
-	MustInvokeNamed[int](i1, "foobar")
+	is.NotPanics(func() {
+		value := MustInvokeNamed[int](i1, "foobar")
+		is.Equal(42, value)
+	})
 	is.Equal(1, count)
 
 	// clone container
@@ -302,7 +305,7 @@ func TestInjectorClone(t *testing.T) {
 	is.Equal(2, count)
 
 	// service can be overriden
-	ProvideNamed(i2, "foobar", func(_ *Injector) (int, error) {
+	OverrideNamed(i2, "foobar", func(_ *Injector) (int, error) {
 		count++
 		return 6 * 9, nil
 	})

--- a/injector_test.go
+++ b/injector_test.go
@@ -278,3 +278,36 @@ func TestInjectorOnServiceInvoke(t *testing.T) {
 	is.Equal(1, i.orderedInvocation["bar"])
 	is.Equal(2, i.orderedInvocationIndex)
 }
+
+func TestInjectorClone(t *testing.T) {
+	is := assert.New(t)
+
+	count := 0
+
+	// setup original container
+	i1 := New()
+	ProvideNamed(i1, "foobar", func(_ *Injector) (int, error) {
+		count++
+		return 42, nil
+	})
+	MustInvokeNamed[int](i1, "foobar")
+	is.Equal(1, count)
+
+	// clone container
+	i2 := i1.Clone()
+	// invoked instance is not reused
+	s1, err := InvokeNamed[int](i2, "foobar")
+	is.NoError(err)
+	is.Equal(42, s1)
+	is.Equal(2, count)
+
+	// service can be overriden
+	ProvideNamed(i2, "foobar", func(_ *Injector) (int, error) {
+		count++
+		return 6 * 9, nil
+	})
+	s2, err := InvokeNamed[int](i2, "foobar")
+	is.NoError(err)
+	is.Equal(54, s2)
+	is.Equal(3, count)
+}

--- a/service.go
+++ b/service.go
@@ -41,6 +41,6 @@ type Shutdownable interface {
 	Shutdown() error
 }
 
-type cloeneableService interface {
+type cloneableService interface {
 	clone() any
 }

--- a/service.go
+++ b/service.go
@@ -9,6 +9,7 @@ type Service[T any] interface {
 	getInstance(*Injector) (T, error)
 	healthcheck() error
 	shutdown() error
+	clone() any
 }
 
 type healthcheckableService interface {
@@ -38,4 +39,8 @@ type Healthcheckable interface {
 
 type Shutdownable interface {
 	Shutdown() error
+}
+
+type cloeneableService interface {
+	clone() any
 }

--- a/service_eager.go
+++ b/service_eager.go
@@ -37,3 +37,7 @@ func (s *ServiceEager[T]) shutdown() error {
 
 	return nil
 }
+
+func (s *ServiceEager[T]) clone() any {
+	return s
+}

--- a/service_lazy.go
+++ b/service_lazy.go
@@ -99,3 +99,13 @@ func (s *ServiceLazy[T]) shutdown() error {
 
 	return nil
 }
+
+func (s *ServiceLazy[T]) clone() any {
+	// reset `build` flag and instance
+	return &ServiceLazy[T]{
+		name: s.name,
+
+		built:    false,
+		provider: s.provider,
+	}
+}


### PR DESCRIPTION
Cloning dependency container would be useful for unit testing.
User can reuse production service registrations and replace some service to mock service.

example:
```go
var injector *do.Injector;
func init() {
    do.Provide[Service](injector, func (i *do.Injector) (Service, error) {
        return &RealService{}, nil
    })
    do.Provide[*App](injector, func (i *do.Injector) (*App, error) {
        return &App{i.MustInvoke[Service](i)}, nil
    })
}

func TestService(t *testing.T) {
    i := injector.Clone()
    defer i.Shutdown()
    // replace Service to MockService
    do.Provide[Service](i, func (i *do.Injector) (Service, error) {
        return &MockService{}, nil
    }))
    app := do.Invoke[*App](i)
    // do unit testing with mocked service
}
```

This usecase is relying on service-overriding behavior and inconsistent with https://github.com/samber/do/issues/1 , so it would be nice if service-overriding behavior is officially supported. 