### PR TITLE
refactor: including package path in implicit service name

### DIFF
--- a/di_test.go
+++ b/di_test.go
@@ -52,27 +52,27 @@ func TestProvide(t *testing.T) {
 
 	is.Len(i.services, 2)
 
-	s1, ok1 := i.services["*do.test"]
+	s1, ok1 := i.services["github.com/samber/do.*test"]
 	is.True(ok1)
 	if ok1 {
 		s, ok := s1.(Service[*test])
 		is.True(ok)
 		if ok {
-			is.Equal("*do.test", s.getName())
+			is.Equal("github.com/samber/do.*test", s.getName())
 		}
 	}
 
-	s2, ok2 := i.services["do.test"]
+	s2, ok2 := i.services["github.com/samber/do.test"]
 	is.True(ok2)
 	if ok2 {
 		s, ok := s2.(Service[test])
 		is.True(ok)
 		if ok {
-			is.Equal("do.test", s.getName())
+			is.Equal("github.com/samber/do.test", s.getName())
 		}
 	}
 
-	_, ok3 := i.services["*do.plop"]
+	_, ok3 := i.services["github.com/samber/do.*plop"]
 	is.False(ok3)
 }
 
@@ -133,7 +133,7 @@ func TestInvoke(t *testing.T) {
 
 	is.Len(i.services, 1)
 
-	s0a, ok0a := i.services["do.test"]
+	s0a, ok0a := i.services["github.com/samber/do.test"]
 	is.True(ok0a)
 
 	s0b, ok0b := s0a.(*ServiceLazy[test])
@@ -348,24 +348,24 @@ func TestDoubleInjection(t *testing.T) {
 		})
 	})
 
-	is.PanicsWithError("DI: service `*do.test` has already been declared", func() {
+	is.PanicsWithError("DI: service `github.com/samber/do.*test` has already been declared", func() {
 		Provide(i, func(i *Injector) (*test, error) {
 			return &test{}, nil
 		})
 	})
 
-	is.PanicsWithError("DI: service `*do.test` has already been declared", func() {
+	is.PanicsWithError("DI: service `github.com/samber/do.*test` has already been declared", func() {
 		ProvideValue(i, &test{})
 	})
 
-	is.PanicsWithError("DI: service `*do.test` has already been declared", func() {
-		ProvideNamed(i, "*do.test", func(i *Injector) (*test, error) {
+	is.PanicsWithError("DI: service `github.com/samber/do.*test` has already been declared", func() {
+		ProvideNamed(i, "github.com/samber/do.*test", func(i *Injector) (*test, error) {
 			return &test{}, nil
 		})
 	})
 
-	is.PanicsWithError("DI: service `*do.test` has already been declared", func() {
-		ProvideNamedValue(i, "*do.test", &test{})
+	is.PanicsWithError("DI: service `github.com/samber/do.*test` has already been declared", func() {
+		ProvideNamedValue(i, "github.com/samber/do.*test", &test{})
 	})
 }
 
@@ -389,7 +389,7 @@ func TestOverride(t *testing.T) {
 		})
 		is.Equal(1, MustInvoke[*test](i).foobar)
 
-		OverrideNamed(i, "*do.test", func(i *Injector) (*test, error) {
+		OverrideNamed(i, "github.com/samber/do.*test", func(i *Injector) (*test, error) {
 			return &test{2}, nil
 		})
 		is.Equal(2, MustInvoke[*test](i).foobar)
@@ -397,7 +397,7 @@ func TestOverride(t *testing.T) {
 		OverrideValue(i, &test{3})
 		is.Equal(3, MustInvoke[*test](i).foobar)
 
-		OverrideNamedValue(i, "*do.test", &test{4})
+		OverrideNamedValue(i, "github.com/samber/do.*test", &test{4})
 		is.Equal(4, MustInvoke[*test](i).foobar)
 	})
 }

--- a/service.go
+++ b/service.go
@@ -1,7 +1,8 @@
 package do
 
 import (
-	"fmt"
+	"reflect"
+	"strings"
 )
 
 type Service[T any] interface {
@@ -22,15 +23,26 @@ type shutdownableService interface {
 
 func generateServiceName[T any]() string {
 	var t T
+	typeOfT := reflect.TypeOf(t)
+	star := 0
 
-	// struct
-	name := fmt.Sprintf("%T", t)
-	if name != "<nil>" {
-		return name
+	if typeOfT == nil {
+		typeOfT = reflect.TypeOf(new(T))
 	}
 
-	// interface
-	return fmt.Sprintf("%T", new(T))
+	for {
+		if typeOfT.Kind() != reflect.Pointer {
+			break
+		}
+		typeOfT = typeOfT.Elem()
+		star++
+	}
+
+	pkgPath := typeOfT.PkgPath()
+	if pkgPath != "" {
+		pkgPath += "."
+	}
+	return pkgPath + strings.Repeat("*", star) + typeOfT.Name()
 }
 
 type Healthcheckable interface {

--- a/service_test.go
+++ b/service_test.go
@@ -9,14 +9,31 @@ import (
 func TestGenerateServiceName(t *testing.T) {
 	is := assert.New(t)
 
-	type test struct{} //nolint:unused
+	type testStruct struct{} //nolint:unused
 
-	name := generateServiceName[test]()
-	is.Equal("do.test", name)
+	type testInterface interface{} //nolint:unused
 
-	name = generateServiceName[*test]()
-	is.Equal("*do.test", name)
+	name := generateServiceName[testStruct]()
+	is.Equal("github.com/samber/do.testStruct", name)
+
+	name = generateServiceName[*testStruct]()
+	is.Equal("github.com/samber/do.*testStruct", name)
+
+	name = generateServiceName[***testStruct]()
+	is.Equal("github.com/samber/do.***testStruct", name)
+
+	name = generateServiceName[testInterface]()
+	is.Equal("github.com/samber/do.*testInterface", name)
+
+	name = generateServiceName[*testInterface]()
+	is.Equal("github.com/samber/do.*testInterface", name)
+
+	name = generateServiceName[***testInterface]()
+	is.Equal("github.com/samber/do.***testInterface", name)
 
 	name = generateServiceName[int]()
 	is.Equal("int", name)
+
+	name = generateServiceName[*int]()
+	is.Equal("*int", name)
 }


### PR DESCRIPTION
Thanks for this great work! I've used it in my open source project.

During use, I found that registering services with the same name will panic,
even if they came from different packages. Here's an minimal repro:

```go
// a/c/a-c.go
package c
import ( /* ... */ )
type MyStruct struct { /* ... */ }
func NewMyStruct(i *do.Injector) (*MyStruct, error) { /* ... */ }

// b/c/b-c.go
package c
import ( /* ... */ )
type MyStruct struct { /* ... */ }
func NewMyStruct(i *do.Injector) (*MyStruct, error) { /* ... */ }

// main.go
package main
import ( /* ... */ )
func main() {
    i := do.New()
    do.Provide(i, ac.NewMyStruct)
    do.Provide(i, bc.NewMyStruct)
}

// panic: DI: service `*c.MyStruct` has already been declared
```

The problem occurs because `generateServiceName()` didn't create
a "global-unique" qualifier for type.
This PR refactors `generateServiceName()` to create
unique qualifiers by prepending package path.

## Implementation

This implementation uses `reflect.TypeOf()`,
which is the same as `fmt.Sprintf("%T")`.
It basically the same as `typeOfT.PkgPath() + "." + typeOfT.Name()`.

For the following code it generates such qualifiers:

```go
// service_test.go
type testStruct struct{}
type testInterface interface{}
```

type|qualifier
-|-
`testStruct`|`github.com/samber/do.testStruct`
`*testStruct`|`github.com/samber/do.*testStruct`
`testInterface`|`github.com/samber/do.*testInterface`
`int`|`int`
`*int`|`*int`

## Alternatives

### `typeOfT.Name()` vs. `typeOfT.String()`

`fmt.Sprintf("%T")` uses `typeOfT.String()`.
But `typeOfT.String()`
[says](https://pkg.go.dev/reflect#Type)
"The string representation **may** use shortened package names
and is not guaranteed to be unique among types."
Therefore it cannot be guaranteed for usage as a type qualifier.

### Processing method of pointer indirect star

The current `do.*test` looks strange
but I haven't thought of a better one yet.

## Testing

Tests have all been updated.
Maybe it's necessary to create two test packages
to test bugs mentioned above,
but adding two new files for this is somewhat weird
so I didn't do that.
Is it necessary?

## Compatibility

This doesn't introduce API changes and therefore
it should be possible to add into v1.
But it introduces internal behavior changes
so please consider it carefully.
