### PR TITLE
Fix option handling for HookAfterRegistration

### DIFF
--- a/injector.go
+++ b/injector.go
@@ -45,7 +45,7 @@ func NewWithOpts(opts *InjectorOpts) *Injector {
 		orderedInvocation:      map[string]int{},
 		orderedInvocationIndex: 0,
 
-		hookAfterRegistration: opts.HookAfterShutdown,
+		hookAfterRegistration: opts.HookAfterRegistration,
 		hookAfterShutdown:     opts.HookAfterShutdown,
 
 		logf: logf,

--- a/injector_example_test.go
+++ b/injector_example_test.go
@@ -52,7 +52,10 @@ func ExampleNewWithOpts() {
 		},
 	})
 
-	ProvideNamedValue(injector, "PG_URI", "postgres://user:pass@host:5432/db")
+	ProvideNamed(injector, "PG_URI", func(i *Injector) (string, error) {
+		return "postgres://user:pass@host:5432/db", nil
+	})
+	MustInvokeNamed[string](injector, "PG_URI")
 	_ = injector.Shutdown()
 
 	// Output:


### PR DESCRIPTION
Just a silly copy-and-paste error probably, but it was certainly confusing watching the logs.