### PR TITLE
add ShutdownOnCtx method and an example

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
 
 	"github.com/samber/do"
 )
@@ -96,6 +99,13 @@ func main() {
 
 	err := injector.Shutdown()
 	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// shutdown using a context example (Ctrl/Cmd+C) example
+	ctx, cancelFunc := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancelFunc()
+	if err := injector.ShutdownOnCtx(ctx); err != nil {
 		log.Fatal(err.Error())
 	}
 }

--- a/injector.go
+++ b/injector.go
@@ -1,6 +1,7 @@
 package do
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -150,6 +151,13 @@ func (i *Injector) ShutdownOnSIGTERM() error {
 	signal.Stop(ch)
 	close(ch)
 
+	return i.Shutdown()
+}
+
+// ShutdownOnCtx listens for the context.Done channel closing to graceful-stop service.
+// It will block until receiving a context.Done channel closing.
+func (i *Injector) ShutdownOnCtx(ctx context.Context) error {
+	<-ctx.Done()
 	return i.Shutdown()
 }
 


### PR DESCRIPTION
In case when an application has more than one shutdown initiator, the context-closing approach can be suitable to use.