### PR TITLE
[proposal] Auto magically inject services

### DIFF
--- a/service.go
+++ b/service.go
@@ -2,11 +2,13 @@ package do
 
 import (
 	"fmt"
+	"reflect"
 )
 
 type Service[T any] interface {
 	getName() string
 	getInstance(*Injector) (T, error)
+	// getInstanceAny(*Injector) (any, error)
 	healthcheck() error
 	shutdown() error
 	clone() any
@@ -20,9 +22,21 @@ type shutdownableService interface {
 	shutdown() error
 }
 
+type anyService interface {
+	getInstanceAny(*Injector) (any, error)
+}
+
+func getServiceNameFromStructField(field *reflect.StructField) string {
+	t := reflect.New(field.Type).Elem().Interface()
+	return getServiceNameFromValue(t)
+}
+
 func generateServiceName[T any]() string {
 	var t T
+	return getServiceNameFromValue(t)
+}
 
+func getServiceNameFromValue[T any](t T) string {
 	// struct
 	name := fmt.Sprintf("%T", t)
 	if name != "<nil>" {

--- a/service_eager.go
+++ b/service_eager.go
@@ -22,6 +22,10 @@ func (s *ServiceEager[T]) getInstance(i *Injector) (T, error) {
 	return s.instance, nil
 }
 
+func (s *ServiceEager[T]) getInstanceAny(i *Injector) (any, error) {
+	return s.getInstance(i)
+}
+
 func (s *ServiceEager[T]) healthcheck() error {
 	instance, ok := any(s.instance).(Healthcheckable)
 	if ok {

--- a/service_lazy.go
+++ b/service_lazy.go
@@ -46,6 +46,11 @@ func (s *ServiceLazy[T]) getInstance(i *Injector) (T, error) {
 }
 
 //nolint:unused
+func (s *ServiceLazy[T]) getInstanceAny(i *Injector) (any, error) {
+	return s.getInstance(i)
+}
+
+//nolint:unused
 func (s *ServiceLazy[T]) build(i *Injector) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,87 @@
+package do
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+const tagName = "do"
+
+func InjectTag[T any](i *Injector, service T) (T, error) {
+	_i := getInjectorOrDefault(i)
+	return populateServiceByTags(_i, service)
+}
+
+func MustInjectTag[T any](i *Injector, service T) T {
+	v, err := InjectTag(i, service)
+	must(err)
+	return v
+}
+
+func populateServiceByTags[T any](i *Injector, service T) (T, error) {
+	// get the underlying value
+	value := reflect.ValueOf(service)
+
+	// return error if provided service is not a pointer
+	if value.Kind() != reflect.Ptr {
+		return empty[T](), fmt.Errorf("DI: expected a pointer")
+	}
+
+	// look for the underlying value type
+	for value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+
+	// check if underlying value is a struct
+	kind := value.Kind()
+	if kind != reflect.Struct {
+		return service, nil
+	}
+
+	tYpe := value.Type()
+
+	// for each field, we try to inject value
+	for j := 0; j < tYpe.NumField(); j++ {
+		field := tYpe.Field(j)
+
+		tag, ok := field.Tag.Lookup(tagName)
+		if !ok {
+			continue
+		}
+
+		serviceName := tag
+		if len(tag) == 0 {
+			serviceName = getServiceNameFromStructField(&field)
+		}
+
+		// fmt.Println("lookup service:", serviceName)
+
+		serviceAny, ok := i.get(serviceName)
+		if !ok {
+			return empty[T](), i.serviceNotFound(serviceName)
+		}
+
+		service, ok := serviceAny.(anyService)
+		if !ok {
+			return empty[T](), i.serviceNotFound(serviceName)
+		}
+
+		instance, err := service.getInstanceAny(i)
+		if err != nil {
+			return empty[T](), err
+		}
+
+		newValue := reflect.ValueOf(instance)
+		if newValue.Type() != field.Type {
+			return empty[T](), fmt.Errorf("DI: type mismatch. Expected '%s', got '%s'", newValue.Type().String(), field.Type.String())
+		}
+
+		// https://stackoverflow.com/questions/42664837/how-to-access-unexported-struct-fields
+		reflect.NewAt(field.Type, unsafe.Pointer(value.Field(j).UnsafeAddr())).
+			Elem().
+			Set(newValue)
+	}
+
+	return service, nil
+}

--- a/tag.go
+++ b/tag.go
@@ -19,6 +19,12 @@ func MustInjectTag[T any](i *Injector, service T) T {
 	return v
 }
 
+func TagProvider[T any](t T) Provider[T] {
+	return func(i *Injector) (T, error) {
+		return InjectTag(i, t)
+	}
+}
+
 func populateServiceByTags[T any](i *Injector, service T) (T, error) {
 	// get the underlying value
 	value := reflect.ValueOf(service)

--- a/tag_test.go
+++ b/tag_test.go
@@ -19,7 +19,7 @@ func TestTag(t *testing.T) {
 		foobar1 string `do:"baz"`
 		foobar2 foobar `do:""`
 		foobar3 *hello `do:""`
-		foobar4 *hello `do`
+		foobar4 *hello `do` //nolint:govet
 		foobar5 string
 	}
 
@@ -46,7 +46,7 @@ func TestTag(t *testing.T) {
 	is.Equal("", v.foobar5)
 
 	type wrongType struct {
-		foobar int `do:"baz"`
+		foobar int `do:"baz"` //nolint:unused
 	}
 
 	_, err = InjectTag(injector, &wrongType{})

--- a/tag_test.go
+++ b/tag_test.go
@@ -51,4 +51,7 @@ func TestTag(t *testing.T) {
 
 	_, err = InjectTag(injector, &wrongType{})
 	is.EqualError(err, "DI: type mismatch. Expected 'string', got 'int'")
+
+	_, err = TagProvider(&test{})(injector)
+	is.Nil(err)
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,54 @@
+package do
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTag(t *testing.T) {
+	is := assert.New(t)
+
+	type foobar string
+
+	type hello struct {
+		world string
+	}
+
+	type test struct {
+		foobar1 string `do:"baz"`
+		foobar2 foobar `do:""`
+		foobar3 *hello `do:""`
+		foobar4 *hello `do`
+		foobar5 string
+	}
+
+	injector := New()
+
+	ProvideNamedValue(injector, "baz", "foobar1")
+	ProvideValue[foobar](injector, "foobar2")
+	Provide(injector, func(i *Injector) (*hello, error) {
+		return &hello{"foobar3"}, nil
+	})
+
+	_, err := InjectTag(injector, test{})
+	is.EqualError(err, "DI: expected a pointer")
+
+	_, err = InjectTag(injector, 42)
+	is.EqualError(err, "DI: expected a pointer")
+
+	v, err := InjectTag(injector, &test{})
+	is.Nil(err)
+	is.Equal("foobar1", v.foobar1)
+	is.Equal(foobar("foobar2"), v.foobar2)
+	is.Equal("foobar3", v.foobar3.world)
+	is.Nil(v.foobar4)
+	is.Equal("", v.foobar5)
+
+	type wrongType struct {
+		foobar int `do:"baz"`
+	}
+
+	_, err = InjectTag(injector, &wrongType{})
+	is.EqualError(err, "DI: type mismatch. Expected 'string', got 'int'")
+}


### PR DESCRIPTION
Linked to #9 

This contribution adds support for a service declaration in struct tags. Such as:

```go
type Car struct {
    Engine *Engine `do:""`
    Brand  string  `do:"awesome-brand"`
    Other  int
}
```

In this proposal, I suggest 3 new helpers:
- `do.InjectTag(do.Injector, Service) (Service, error) `
- `do.MustInjectTag(do.Injector, Service) (Service)`
- `do.TagProvider[T any](t T) Provider[T]`

This implementation is obviously unsafe since it uses `reflect` and `unsafe` std libs.

Example:

```go
type Engine struct {
    Watt int
}

func NewEngine(i *do.Injector) (*Engine, error) {
    return &Engine{42}, nil
}

do.Provide(injector, NewEngine)
```

```go
do.ProvideNamedValue(injector, "awesome-brand", "tesla")
```

```go
type Car struct {
    Engine *Engine `do:""`
    Brand  string  `do:"awesome-brand"`
    Other  int
}

func NewCar(i *do.Injector) (*Car, error) {
    return do.InjectTag(i, &Car{})
}

do.Provide(injector, NewCar)
// could be replaced by do.Provide(injector, do.TagProvider(&Car{}))
```

IMO, we should avoid calling this helper automatically on service invocation. It would be error-prone and costly. Being declarative also allows the developer to execute `do.InjectTag` at the right time in the provider.

`do.TagProvider` would be a shortcut for very simple providers:

```go
do.Provide(injector, do.TagProvider(&Car{}))

// is equivalent to:

do.Provide(injector, NewCar(i *do.Injector) (*Car, error) {
    return do.InjectTag(i, &Car{})
})
```

I would be very happy to receive feedback about this!