### PR TITLE
Implement custom shutdown function

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If your component is `io.Closer` or having other cleanup method, you can use cus
 
 ```go
 injector := do.New()
-do.Provide(injector, func(i *do.Injector) {
+do.Provide(injector, func(i *do.Injector) (*sql.DB, error) {
     return sql.Open(...)
 }, do.WithShutdownFunc(func (db *sql.DB) error {
     return db.Close()

--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ do.Invoke(injector, ...)
 injector.Shutdown()
 ```
 
+If your component is `io.Closer` or having other cleanup method, you can use custom shutdown with `do.Provide(..., do.WithShutdown(func (i *Injector) error { ... }))`.
+
+```go
+injector := do.New()
+do.Provide(injector, func(i *do.Injector) {
+    return sql.Open(...)
+}, do.WithShutdownFunc(func (db *sql.DB) error {
+    return db.Close()
+}))
+
+do.Invoke[*sql.DB](injector)
+injector.Shutdown()
+```
+
 List services:
 
 ```go

--- a/di.go
+++ b/di.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func Provide[T any](i *Injector, provider Provider[T]) {
+func Provide[T any](i *Injector, provider Provider[T], opts ...ServiceOpt[T]) {
 	name := generateServiceName[T]()
 
 	_i := getInjectorOrDefault(i)
@@ -12,25 +12,25 @@ func Provide[T any](i *Injector, provider Provider[T]) {
 		panic(fmt.Errorf("DI: service `%s` has already been declared", name))
 	}
 
-	service := newServiceLazy(name, provider)
+	service := newServiceLazy(name, provider, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s injected", name)
 }
 
-func ProvideNamed[T any](i *Injector, name string, provider Provider[T]) {
+func ProvideNamed[T any](i *Injector, name string, provider Provider[T], opts ...ServiceOpt[T]) {
 	_i := getInjectorOrDefault(i)
 	if _i.exists(name) {
 		panic(fmt.Errorf("DI: service `%s` has already been declared", name))
 	}
 
-	service := newServiceLazy(name, provider)
+	service := newServiceLazy(name, provider, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s injected", name)
 }
 
-func ProvideValue[T any](i *Injector, value T) {
+func ProvideValue[T any](i *Injector, value T, opts ...ServiceOpt[T]) {
 	name := generateServiceName[T]()
 
 	_i := getInjectorOrDefault(i)
@@ -38,59 +38,59 @@ func ProvideValue[T any](i *Injector, value T) {
 		panic(fmt.Errorf("DI: service `%s` has already been declared", name))
 	}
 
-	service := newServiceEager(name, value)
+	service := newServiceEager(name, value, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s injected", name)
 }
 
-func ProvideNamedValue[T any](i *Injector, name string, value T) {
+func ProvideNamedValue[T any](i *Injector, name string, value T, opts ...ServiceOpt[T]) {
 	_i := getInjectorOrDefault(i)
 	if _i.exists(name) {
 		panic(fmt.Errorf("DI: service `%s` has already been declared", name))
 	}
 
-	service := newServiceEager(name, value)
+	service := newServiceEager(name, value, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s injected", name)
 }
 
-func Override[T any](i *Injector, provider Provider[T]) {
+func Override[T any](i *Injector, provider Provider[T], opts ...ServiceOpt[T]) {
 	name := generateServiceName[T]()
 
 	_i := getInjectorOrDefault(i)
 
-	service := newServiceLazy(name, provider)
+	service := newServiceLazy(name, provider, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s overridden", name)
 }
 
-func OverrideNamed[T any](i *Injector, name string, provider Provider[T]) {
+func OverrideNamed[T any](i *Injector, name string, provider Provider[T], opts ...ServiceOpt[T]) {
 	_i := getInjectorOrDefault(i)
 
-	service := newServiceLazy(name, provider)
+	service := newServiceLazy(name, provider, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s overridden", name)
 }
 
-func OverrideValue[T any](i *Injector, value T) {
+func OverrideValue[T any](i *Injector, value T, opts ...ServiceOpt[T]) {
 	name := generateServiceName[T]()
 
 	_i := getInjectorOrDefault(i)
 
-	service := newServiceEager(name, value)
+	service := newServiceEager(name, value, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s overridden", name)
 }
 
-func OverrideNamedValue[T any](i *Injector, name string, value T) {
+func OverrideNamedValue[T any](i *Injector, name string, value T, opts ...ServiceOpt[T]) {
 	_i := getInjectorOrDefault(i)
 
-	service := newServiceEager(name, value)
+	service := newServiceEager(name, value, opts...)
 	_i.set(name, service)
 
 	_i.logf("service %s overridden", name)

--- a/service.go
+++ b/service.go
@@ -8,6 +8,7 @@ type Service[T any] interface {
 	getName() string
 	getInstance(*Injector) (T, error)
 	healthcheck() error
+	setShutdownFunc(shutdownFunc[T])
 	shutdown() error
 	clone() any
 }
@@ -19,6 +20,8 @@ type healthcheckableService interface {
 type shutdownableService interface {
 	shutdown() error
 }
+
+type shutdownFunc[T any] func(instance T) error
 
 func generateServiceName[T any]() string {
 	var t T

--- a/service_opts.go
+++ b/service_opts.go
@@ -1,0 +1,19 @@
+package do
+
+type ServiceOpt[T any] func(Service[T])
+
+// custom shutdown
+
+func noopShutdownFunc[T any](instance T) error {
+	return nil
+}
+
+func WithShutdownFunc[T any](shutdownFunc shutdownFunc[T]) ServiceOpt[T] {
+	return func(s Service[T]) {
+		if shutdownFunc == nil {
+			// disable default shutdown if nil specified
+			shutdownFunc = noopShutdownFunc[T]
+		}
+		s.setShutdownFunc(shutdownFunc)
+	}
+}


### PR DESCRIPTION
When using third-party types like *sql.DB or *redis.Client, it is often necessary to create a new type to specify the Shutdown behavior. 

```go
type DBWithShutdown sql.DB

func (db *DBWithShutdown) Shutdown() error {
    return db.Close()
}
```

This not only requires defining an additional type but also requires additional type conversions.

My proposal is:
- To allow specifying options in the arguments of `ProvideXXX`, with functional optional pattern
- Customize `Shutdown` behavior with `WithShutdownFunc` option

```go
injector := do.New()
do.Provide(injector, func(i *do.Injector) {
    return sql.Open(...)
}, do.WithShutdownFunc(func (db *sql.DB) error {
    return db.Close()
}))

do.Invoke[*sql.DB](injector)
injector.Shutdown()
```