### PR TITLE
shutdown-all-services-even-on-error

### DIFF
--- a/examples/shutdownable/example.go
+++ b/examples/shutdownable/example.go
@@ -76,8 +76,10 @@ func main() {
 	car := do.MustInvoke[*Car](injector)
 	car.Start()
 
-	err := injector.Shutdown()
-	if err != nil {
-		log.Fatal(err.Error())
+	shutdown := injector.Shutdown()
+	for _, err := range shutdown {
+		if err != nil {
+			log.Println(err)
+		}
 	}
 }

--- a/injector_example_test.go
+++ b/injector_example_test.go
@@ -123,11 +123,11 @@ func ExampleInjector_Shutdown() {
 	injector := New()
 
 	Provide(injector, dbServiceProvider)
-	err := injector.Shutdown()
+	shutdown := injector.Shutdown()
 
-	fmt.Println(err)
+	fmt.Println(shutdown)
 	// Output:
-	// <nil>
+	// map[]
 }
 
 func ExampleInjector_Clone() {

--- a/injector_test.go
+++ b/injector_test.go
@@ -38,8 +38,10 @@ func TestInjectorNewWithOpts(t *testing.T) {
 		MustInvokeNamed[int](i, "foobar")
 	})
 
-	err := i.Shutdown()
-	is.Nil(err)
+	shutdown := i.Shutdown()
+	for _, err := range shutdown {
+		is.Nil(err)
+	}
 
 	is.Equal(2, count)
 }


### PR DESCRIPTION
#42 "Currently when Injector.Shutdown receives an error while calling Shutdown on a service, it aborts and never calls Shutdown on the following services. It would be nice to have it behave like Injector.HealthCheck were all services are called regardless of their returned errors."