### PR TITLE
[👷] Road to v2 🚀 - Refactor DAG Maps to sync.Map and Improve invoke Function Readability

### DIFF
--- a/di.go
+++ b/di.go
@@ -118,9 +118,7 @@ func Invoke[T any](i Injector) (T, error) {
 
 // MustInvoke invokes a service in the DI container, using type inference to determine the service name. It panics on error.
 func MustInvoke[T any](i Injector) T {
-	s, err := Invoke[T](i)
-	must0(err)
-	return s
+	return must1(Invoke[T](i))
 }
 
 // InvokeNamed invokes a named service in the DI container.
@@ -130,7 +128,5 @@ func InvokeNamed[T any](i Injector, name string) (T, error) {
 
 // MustInvokeNamed invokes a named service in the DI container. It panics on error.
 func MustInvokeNamed[T any](i Injector, name string) T {
-	s, err := InvokeNamed[T](i, name)
-	must0(err)
-	return s
+	return must1(InvokeNamed[T](i, name))
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,6 @@
+package do
+
+import "errors"
+
+var ErrServiceNotFound = errors.New("DI: could not find service")
+var ErrCircularDependency = errors.New("DI: circular dependency detected")

--- a/invoke.go
+++ b/invoke.go
@@ -6,32 +6,33 @@ import (
 	"strings"
 )
 
-// invokeByName look for a service by its name.
+// invokeByName looks for a service by its name.
 func invokeByName[T any](i Injector, name string) (T, error) {
-	_i := getInjectorOrDefault(i)
+	var invokerChain []string
 
-	invokerName := ""
-	invokerChain := []string{}
-	if vs, ok := _i.(*virtualScope); ok {
-		if len(vs.invokerChain) > 0 {
-			invokerName = vs.invokerChain[len(vs.invokerChain)-1]
-		}
+	injector := getInjectorOrDefault(i)
 
-		invokerChain = vs.invokerChain
+	vScope, isVirtualScope := injector.(*virtualScope)
+	if isVirtualScope {
+		invokerChain = vScope.invokerChain
 
-		if contains(invokerChain, name) {
-			return empty[T](), fmt.Errorf("DI: circular dependency detected: %s -> %s", strings.Join(invokerChain, " -> "), name)
+		if err := vScope.detectCircularDependency(name); err != nil {
+			return empty[T](), err
 		}
 	}
 
-	serviceAny, serviceScope, ok := _i.serviceGetRec(name)
-	if !ok {
-		return empty[T](), serviceNotFound(_i, name)
+	serviceAny, serviceScope, found := injector.serviceGetRec(name)
+	if !found {
+		return empty[T](), serviceNotFound(injector, name)
+	}
+
+	if isVirtualScope {
+		vScope.addDependency(injector, name, serviceScope)
 	}
 
 	service, ok := serviceAny.(Service[T])
 	if !ok {
-		return empty[T](), serviceNotFound(_i, name)
+		return empty[T](), serviceNotFound(injector, name)
 	}
 
 	instance, err := service.getInstance(&virtualScope{invokerChain: append(invokerChain, name), self: serviceScope})
@@ -39,12 +40,9 @@ func invokeByName[T any](i Injector, name string) (T, error) {
 		return empty[T](), err
 	}
 
-	if _, ok := _i.(*virtualScope); ok {
-		_i.RootScope().dag.addDependency(_i.ID(), _i.Name(), invokerName, serviceScope.ID(), serviceScope.Name(), name)
-	}
-
 	serviceScope.onServiceInvoke(name)
-	_i.RootScope().opts.Logf("DI: service %s invoked", name)
+
+	injector.RootScope().opts.Logf("DI: service %s invoked", name)
 
 	return instance, nil
 }
@@ -53,30 +51,30 @@ func invokeByName[T any](i Injector, name string) (T, error) {
 // When many services match, the first service matching
 // the provided type or interface will be invoked.
 func invokeByGenericType[T any](i Injector) (T, error) {
-	_i := getInjectorOrDefault(i)
+	injector := getInjectorOrDefault(i)
 	serviceAliasName := inferServiceName[T]()
 
-	invokerName := ""
-	invokerChain := []string{}
-	if vs, ok := _i.(*virtualScope); ok {
-		if len(vs.invokerChain) > 0 {
-			invokerName = vs.invokerChain[len(vs.invokerChain)-1]
-		}
+	var invokerChain []string
 
-		invokerChain = vs.invokerChain
-
-		// compared to invoke(), we check for circular dependencies lazily
+	vScope, isVirtualScope := injector.(*virtualScope)
+	if isVirtualScope {
+		invokerChain = vScope.invokerChain
 	}
 
-	var service any
+	var serviceInstance any
 	var serviceScope *Scope
-	var ok bool = false
-	_i.serviceForEachRec(func(name string, scope *Scope, s any) bool {
+	var serviceRealName string
+	var ok bool
+
+	injector.serviceForEachRec(func(name string, scope *Scope, s any) bool {
 		if serviceIsAssignable[T](s) {
 			// we need an empty instance here, because we don't want to instantiate the service when not needed
-			service = s
+
+			serviceInstance = s
 			serviceScope = scope
+			serviceRealName = s.(serviceGetName).getName()
 			ok = true
+
 			return false
 		}
 
@@ -84,52 +82,63 @@ func invokeByGenericType[T any](i Injector) (T, error) {
 	})
 
 	if !ok {
-		return empty[T](), serviceNotFound(_i, serviceAliasName)
+		return empty[T](), serviceNotFound(injector, serviceAliasName)
 	}
 
-	// We chose to register the real service name in invocation chain, because using the
-	// interface name would break cycle detection.
-	serviceRealName := service.(serviceGetName).getName()
-
-	// Check for circular dependencies.
-	for i := range invokerChain {
-		if invokerChain[i] == serviceRealName {
-			return empty[T](), fmt.Errorf("DI: circular dependency detected: %s -> %s", strings.Join(invokerChain, " -> "), serviceRealName)
+	if isVirtualScope {
+		if err := vScope.detectCircularDependency(serviceRealName); err != nil {
+			return empty[T](), err
 		}
 	}
 
-	instance, err := service.(serviceGetInstanceAny).getInstanceAny(&virtualScope{invokerChain: append(invokerChain, serviceRealName), self: serviceScope})
+	instance, err := serviceInstance.(serviceGetInstanceAny).getInstanceAny(
+		&virtualScope{
+			invokerChain: append(invokerChain, serviceRealName),
+			self:         serviceScope,
+		},
+	)
 	if err != nil {
 		return empty[T](), err
 	}
 
-	if _, ok := _i.(*virtualScope); ok {
-		// Should we use the alias name or the real name?
-		_i.RootScope().dag.addDependency(_i.ID(), _i.Name(), invokerName, serviceScope.ID(), serviceScope.Name(), serviceRealName)
+	if isVirtualScope {
+		// We chose to register the real service name in invocation chain, because using the
+		// interface name would break cycle detection.
+
+		vScope.addDependency(injector, serviceRealName, serviceScope)
 	}
 
-	serviceScope.onServiceInvoke(serviceRealName)                        // from the service POV, we use the real name injected into the scope
-	_i.RootScope().opts.Logf("DI: service %s invoked", serviceAliasName) // from the invoker POV, we use the alias name
+	serviceScope.onServiceInvoke(serviceRealName)
+
+	injector.RootScope().opts.Logf("DI: service %s invoked", serviceAliasName)
 
 	return instance.(T), nil
 }
 
+// serviceNotFound returns an error indicating that the specified service was not found.
 func serviceNotFound(injector Injector, name string) error {
-	// @TODO: use the Keys+Map functions from `golang.org/x/exp/maps` as
-	// soon as it is released in stdlib.
 	services := injector.ListProvidedServices()
-	servicesNames := mAp(services, func(edge EdgeService, _ int) string {
-		return fmt.Sprintf("`%s`", edge.Service)
-	})
 
-	// cool for unit tests
-	sorter := sort.StringSlice(servicesNames)
-	sorter.Sort()
-	servicesNames = []string(sorter)
-
-	if len(servicesNames) == 0 {
-		return fmt.Errorf("DI: could not find service `%s`, no service available", name)
+	if len(services) == 0 {
+		return fmt.Errorf("%w `%s`, no service available", ErrServiceNotFound, name)
 	}
 
-	return fmt.Errorf("DI: could not find service `%s`, available services: %s", name, strings.Join(servicesNames, ", "))
+	serviceNames := getServiceNames(services)
+	sortedServiceNames := sortServiceNames(serviceNames)
+
+	return fmt.Errorf("%w `%s`, available services: %s", ErrServiceNotFound, name, strings.Join(sortedServiceNames, ", "))
+}
+
+// getServiceNames formats a list of EdgeService names.
+func getServiceNames(services []EdgeService) []string {
+	return mAp(services, func(edge EdgeService, _ int) string {
+		return fmt.Sprintf("`%s`", edge.Service)
+	})
+}
+
+// sortServiceNames sorts a list of service names.
+func sortServiceNames(names []string) []string {
+	sort.Strings(names)
+
+	return names
 }


### PR DESCRIPTION
This PR introduces improvements to the codebase by replacing certain maps and mutexes with sync.Map for enhanced concurrency safety. Additionally, modifications have been made to the invoke function to improve its readability, making the code more comprehensible.

Relates to https://github.com/samber/do/pull/45

# Changes:

## Utilization of sync.Map:

Replaced existing maps and mutexes with sync.Map for improved concurrency handling.
This enhances the safety and efficiency of the code, particularly in scenarios involving concurrent access to maps.

## Enhanced invoke Function:

Made changes to the invoke function to enhance readability.
Improved the structure and clarity of the code for easier understanding and maintenance.

### Purpose:

The goal of these changes is to enhance the overall robustness and clarity of the codebase. The adoption of sync.Map improves concurrent map operations, while the refactoring of the invoke function aims to make the code more legible and maintainable.

# Testing:

The changes have been tested to ensure that the refactored code retains its functionality and performs as expected. Unit tests have been executed to validate the correctness of the modifications.