### PR TITLE
feat: let pass our own chan to ShutdownOnSignals

### DIFF
--- a/examples/nested-scope/example.go
+++ b/examples/nested-scope/example.go
@@ -27,5 +27,5 @@ func main() {
 	driver.TakeASeat()
 	passenger.TakeASeat()
 
-	fmt.Println(injector.ShutdownOnSignals())
+	fmt.Println(injector.ShutdownOnSignals(nil))
 }

--- a/examples/shutdownable/example.go
+++ b/examples/shutdownable/example.go
@@ -94,7 +94,7 @@ func main() {
 	car := do.MustInvoke[*Car](injector)
 	car.Start()
 
-	_, err := injector.ShutdownOnSignals()
+	_, err := injector.ShutdownOnSignals(nil)
 	for _, e := range err {
 		if e != nil {
 			log.Fatal(e.Error())

--- a/root_scope.go
+++ b/root_scope.go
@@ -142,20 +142,24 @@ func (s *RootScope) CloneWithOpts(opts *InjectorOpts) *RootScope {
 // ShutdownOnSignals listens for signals defined in signals parameter in order to graceful stop service.
 // It will block until receiving any of these signal.
 // If no signal is provided in signals parameter, syscall.SIGTERM and os.Interrupt will be added as default signal.
-func (s *RootScope) ShutdownOnSignals(signals ...os.Signal) (os.Signal, map[string]error) {
-	return s.ShutdownOnSignalsWithContext(context.Background(), signals...)
+// The ch parameter is a channel on which the signals will be received. If ch is nil, a new channel will be created.
+func (s *RootScope) ShutdownOnSignals(ch chan os.Signal, signals ...os.Signal) (os.Signal, map[string]error) {
+	return s.ShutdownOnSignalsWithContext(ch, context.Background(), signals...)
 }
 
 // ShutdownOnSignalsWithContext listens for signals defined in signals parameter in order to graceful stop service.
 // It will block until receiving any of these signal.
 // If no signal is provided in signals parameter, syscall.SIGTERM and os.Interrupt will be added as default signal.
-func (s *RootScope) ShutdownOnSignalsWithContext(ctx context.Context, signals ...os.Signal) (os.Signal, map[string]error) {
+// The ch parameter is a channel on which the signals will be received. If ch is nil, a new channel will be created.
+func (s *RootScope) ShutdownOnSignalsWithContext(ch chan os.Signal, ctx context.Context, signals ...os.Signal) (os.Signal, map[string]error) {
 	// Make sure there is at least syscall.SIGTERM and os.Interrupt as a signal
 	if len(signals) < 1 {
 		signals = append(signals, syscall.SIGTERM, os.Interrupt)
 	}
 
-	ch := make(chan os.Signal, 5)
+	if ch == nil {
+		ch = make(chan os.Signal, 5)
+	}
 	signal.Notify(ch, signals...)
 
 	sig := <-ch

--- a/root_scope.go
+++ b/root_scope.go
@@ -158,7 +158,7 @@ func (s *RootScope) ShutdownOnSignalsWithContext(ch chan os.Signal, ctx context.
 	}
 
 	if ch == nil {
-		ch = make(chan os.Signal, 5)
+		ch = make(chan os.Signal, 1)
 	}
 	signal.Notify(ch, signals...)
 


### PR DESCRIPTION
Passing your own channel as an argument to these methods allows you to have control over the communication channel used to receive signals. That is very useful for my custom signal handling logic.