### PR TITLE
add ShutdownOnSignalsWithContextDone()

### DIFF
--- a/root_scope_test.go
+++ b/root_scope_test.go
@@ -234,3 +234,16 @@ func TestRootScope_ShutdownOnSignals(t *testing.T) {
 func TestRootScope_ShutdownOnSignalsWithContext(t *testing.T) {
 	// @TODO
 }
+
+func TestRootScope_ShutdownOnSignalsWithContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	is := assert.New(t)
+
+	i := New()
+
+	go func() {
+		cancel()
+	}()
+	i.ShutdownOnSignalsWithContextDone(ctx)
+	is.Len(i.Children(), 0)
+}


### PR DESCRIPTION
Hello. Thanks for this great library.

To combine different approaches (signals, context) to control program termination, I propose to expand the API with a new function ShutdownOnSignalsWithContextDone.  Most often it is necessary to combine program termination conditions (some libraries support context , some provide separate stopping functions).
 Services often have dependencies on each other and on IO. This function terminates services if the context is closed.