### PR TITLE
Lock Around Service Shutdown Cleanup

### DIFF
--- a/injector.go
+++ b/injector.go
@@ -198,8 +198,10 @@ func (i *Injector) shutdownImplem(name string) error {
 		}
 	}
 
+	i.mu.Lock()
 	delete(i.services, name)
 	delete(i.orderedInvocation, name)
+	i.mu.Unlock()
 
 	i.onServiceShutdown(name)
 

--- a/injector.go
+++ b/injector.go
@@ -107,11 +107,12 @@ func (i *Injector) HealthCheck() map[string]error {
 func (i *Injector) Shutdown() error {
 	i.mu.RLock()
 	invocations := invertMap(i.orderedInvocation)
+	invocationIndex := i.orderedInvocationIndex
 	i.mu.RUnlock()
 
 	i.logf("requested shutdown")
 
-	for index := i.orderedInvocationIndex; index >= 0; index-- {
+	for index := invocationIndex; index >= 0; index-- {
 		name, ok := invocations[index]
 		if !ok {
 			continue


### PR DESCRIPTION
We are getting periodic flaky tests when shutting down services. The stack trace points back to the delete from i.services.

I'm unable to figure out how to write a test that consistently reproduces the issue.