### PR TITLE
feat: InvokeNamed[any] without type check

### DIFF
--- a/di.go
+++ b/di.go
@@ -114,7 +114,7 @@ func override[T any, A any](i Injector, name string, valueOrProvider A, serviceC
 // Invoke invokes a service in the DI container, using type inference to determine the service name.
 func Invoke[T any](i Injector) (T, error) {
 	name := inferServiceName[T]()
-	return InvokeNamed[T](i, name)
+	return invokeByName[T](i, name)
 }
 
 // MustInvoke invokes a service in the DI container, using type inference to determine the service name. It panics on error.
@@ -124,6 +124,12 @@ func MustInvoke[T any](i Injector) T {
 
 // InvokeNamed invokes a named service in the DI container.
 func InvokeNamed[T any](i Injector, name string) (T, error) {
+	if typesEqual[T, any]() {
+		v, err := invokeAnyByName(i, name)
+		t, _ := v.(T) // just skip if v == nil
+		return t, err
+	}
+
 	return invokeByName[T](i, name)
 }
 

--- a/di_test.go
+++ b/di_test.go
@@ -255,6 +255,7 @@ func TestProvideTransient(t *testing.T) {
 
 	// @TODO: check that all services share the same references
 }
+
 func TestProvideNamedTransient(t *testing.T) {
 	is := assert.New(t)
 
@@ -460,6 +461,11 @@ func TestInvoke(t *testing.T) {
 	_, err2 := Invoke[*test](i)
 	is.NotNil(err2)
 	is.Errorf(err2, "do: service not found")
+
+	ProvideNamedValue(i, NameOf[any](), 0)
+
+	_, err3 := Invoke[any](i)
+	is.ErrorContains(err3, "type mismatch: invoking `interface {}` but registered `int`")
 }
 
 func TestMustInvoke(t *testing.T) {
@@ -512,9 +518,17 @@ func TestInvokeNamed(t *testing.T) {
 	is.EqualValues(_test, instance1)
 	is.EqualValues("foobar", instance1.foobar)
 
+	instance1any, err2 := InvokeNamed[any](i, "hello")
+	is.Nil(err2)
+	is.Equal(instance1, instance1any)
+
 	instance2, err2 := InvokeNamed[int](i, "foobar")
 	is.Nil(err2)
 	is.EqualValues(42, instance2)
+
+	instance2any, err2 := InvokeNamed[any](i, "foobar")
+	is.Nil(err2)
+	is.Equal(instance2, instance2any)
 
 	instance3, err3 := InvokeNamed[string](i, "foobar")
 	is.EqualError(err3, "DI: service found, but type mismatch: invoking `string` but registered `int`")

--- a/utils.go
+++ b/utils.go
@@ -74,6 +74,11 @@ func mAp[T any, R any](collection []T, iteratee func(T, int) R) []R {
 	return result
 }
 
+func typesEqual[A, B any]() bool {
+	_, ok := any((*A)(nil)).(*B)
+	return ok
+}
+
 func filter[V any](collection []V, predicate func(item V, index int) bool) []V {
 	result := make([]V, 0, len(collection))
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -122,6 +122,27 @@ func TestUtilsInvertMap(t *testing.T) {
 	// is.Equal(result2, map[int]string{1: "b", 3: "c"})
 }
 
+func TestTypesEqual(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.True(typesEqual[any, any]())
+	is.True(typesEqual[*any, *any]())
+	is.True(typesEqual[int, int]())
+	is.True(typesEqual[struct{}, struct{}]())
+	is.True(typesEqual[struct{ int }, struct{ int }]())
+	is.True(typesEqual[interface{}, any]())
+	is.True(typesEqual[interface{ fun() }, interface{ fun() }]())
+
+	is.False(typesEqual[int, any]())
+	is.False(typesEqual[*any, any]())
+	is.False(typesEqual[int, string]())
+	is.False(typesEqual[string, any]())
+	is.False(typesEqual[struct{ int }, struct{ any }]())
+	is.False(typesEqual[any, interface{ fun() }]())
+	is.False(typesEqual[interface{ fun1() }, interface{ fun2() }]())
+}
+
 func TestFilter(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)


### PR DESCRIPTION
https://github.com/samber/do/issues/60

The most strict option is proposed here - only for `InvokeNamed`
Not affect for `Invoke[any]`

Might make sense also for `AsNamed`