### PR TITLE
Use reflection instead of fmt

### DIFF
--- a/service.go
+++ b/service.go
@@ -1,7 +1,7 @@
 package do
 
 import (
-	"fmt"
+	"reflect"
 )
 
 type Service[T any] interface {
@@ -24,13 +24,13 @@ func generateServiceName[T any]() string {
 	var t T
 
 	// struct
-	name := fmt.Sprintf("%T", t)
+	name := reflect.TypeOf(t).String()
 	if name != "<nil>" {
 		return name
 	}
 
 	// interface
-	return fmt.Sprintf("%T", new(T))
+	return reflect.TypeOf((new(T))).String()
 }
 
 type Healthcheckable interface {


### PR DESCRIPTION
`%T` uses `reflect.TypeOf(...).String()` under the hood, so it makes sense to just bypass the whole fmt.Sprintf mechanism and call `reflect.TypeOf` directly.

See <https://github.com/golang/go/blob/2ebaff4890596ed6064e2dcbbe5e68bc93bed882/src/fmt/print.go#L698-L700>
