### PR TITLE
V1 improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ watch-test:
 
 bench:
 	go test -benchmem -count 3 -bench ./...
+
 watch-bench:
 	reflex -t 50ms -s -- sh -c 'go test -benchmem -count 3 -bench ./...'
 
@@ -36,6 +37,7 @@ tools:
 
 lint:
 	golangci-lint run --timeout 60s --max-same-issues 50 ./...
+
 lint-fix:
 	golangci-lint run --timeout 60s --max-same-issues 50 --fix ./...
 

--- a/di.go
+++ b/di.go
@@ -7,7 +7,7 @@ import (
 func Provide[T any](i *Injector, provider Provider[T]) {
 	name := generateServiceName[T]()
 
-	ProvideNamed[T](i, name, provider)
+	ProvideNamed(i, name, provider)
 }
 
 func ProvideNamed[T any](i *Injector, name string, provider Provider[T]) {
@@ -43,7 +43,7 @@ func ProvideNamedValue[T any](i *Injector, name string, value T) {
 func Override[T any](i *Injector, provider Provider[T]) {
 	name := generateServiceName[T]()
 
-	OverrideNamed[T](i, name, provider)
+	OverrideNamed(i, name, provider)
 }
 
 func OverrideNamed[T any](i *Injector, name string, provider Provider[T]) {
@@ -58,7 +58,7 @@ func OverrideNamed[T any](i *Injector, name string, provider Provider[T]) {
 func OverrideValue[T any](i *Injector, value T) {
 	name := generateServiceName[T]()
 
-	OverrideNamedValue[T](i, name, value)
+	OverrideNamedValue(i, name, value)
 }
 
 func OverrideNamedValue[T any](i *Injector, name string, value T) {

--- a/di.go
+++ b/di.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Provide[T any](i *Injector, provider Provider[T]) {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 
 	ProvideNamed(i, name, provider)
 }
@@ -23,7 +23,7 @@ func ProvideNamed[T any](i *Injector, name string, provider Provider[T]) {
 }
 
 func ProvideValue[T any](i *Injector, value T) {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 
 	ProvideNamedValue(i, name, value)
 }
@@ -41,7 +41,7 @@ func ProvideNamedValue[T any](i *Injector, name string, value T) {
 }
 
 func Override[T any](i *Injector, provider Provider[T]) {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 
 	OverrideNamed(i, name, provider)
 }
@@ -56,7 +56,7 @@ func OverrideNamed[T any](i *Injector, name string, provider Provider[T]) {
 }
 
 func OverrideValue[T any](i *Injector, value T) {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 
 	OverrideNamedValue(i, name, value)
 }
@@ -71,7 +71,7 @@ func OverrideNamedValue[T any](i *Injector, name string, value T) {
 }
 
 func Invoke[T any](i *Injector) (T, error) {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 	return InvokeNamed[T](i, name)
 }
 
@@ -117,7 +117,7 @@ func invokeImplem[T any](i *Injector, name string) (T, error) {
 }
 
 func HealthCheck[T any](i *Injector) error {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 	return getInjectorOrDefault(i).healthcheckImplem(name)
 }
 
@@ -126,12 +126,12 @@ func HealthCheckNamed(i *Injector, name string) error {
 }
 
 func Shutdown[T any](i *Injector) error {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 	return getInjectorOrDefault(i).shutdownImplem(name)
 }
 
 func MustShutdown[T any](i *Injector) {
-	name := generateServiceName[T]()
+	name := generateServiceNameFromInjector[T](i)
 	must(getInjectorOrDefault(i).shutdownImplem(name))
 }
 

--- a/di.go
+++ b/di.go
@@ -1,6 +1,7 @@
 package do
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -141,4 +142,22 @@ func ShutdownNamed(i *Injector, name string) error {
 
 func MustShutdownNamed(i *Injector, name string) {
 	must(getInjectorOrDefault(i).shutdownImplem(name))
+}
+
+func ShutdownContext[T any](ctx context.Context, i *Injector) error {
+	name := generateServiceNameFromInjector[T](i)
+	return getInjectorOrDefault(i).shutdownContextImplem(ctx, name)
+}
+
+func MustShutdownContext[T any](ctx context.Context, i *Injector) {
+	name := generateServiceNameFromInjector[T](i)
+	must(getInjectorOrDefault(i).shutdownContextImplem(ctx, name))
+}
+
+func ShutdownNamedContext(ctx context.Context, i *Injector, name string) error {
+	return getInjectorOrDefault(i).shutdownContextImplem(ctx, name)
+}
+
+func MustShutdownNamedContext(ctx context.Context, i *Injector, name string) {
+	must(getInjectorOrDefault(i).shutdownContextImplem(ctx, name))
 }

--- a/di.go
+++ b/di.go
@@ -25,7 +25,7 @@ func ProvideNamed[T any](i *Injector, name string, provider Provider[T]) {
 func ProvideValue[T any](i *Injector, value T) {
 	name := generateServiceName[T]()
 
-	ProvideNamedValue[T](i, name, value)
+	ProvideNamedValue(i, name, value)
 }
 
 func ProvideNamedValue[T any](i *Injector, name string, value T) {

--- a/di_test.go
+++ b/di_test.go
@@ -161,12 +161,7 @@ func TestInvokeCircularDependency(t *testing.T) {
 		i := New()
 
 		Provide(i, func(i *Injector) (test, error) {
-			instance, err := Invoke[test](i)
-			if err != nil {
-				return test{}, nil
-			}
-
-			return instance, nil
+			return MustInvoke[test](i), nil
 		})
 
 		is.Panics(func() {

--- a/di_test.go
+++ b/di_test.go
@@ -153,6 +153,27 @@ func TestInvoke(t *testing.T) {
 	is.Errorf(err2, "do: service not found")
 }
 
+func TestInvokeCircularDependency(t *testing.T) {
+	is := assert.New(t)
+
+	type test struct{}
+
+	i := New()
+
+	is.Panics(func() {
+		Provide(i, func(i *Injector) (test, error) {
+			instance, err := Invoke[test](i)
+			if err != nil {
+				return test{}, nil
+			}
+
+			return instance, nil
+		})
+
+		_ = MustInvoke[test](i)
+	}, "circular dependency was not detected (this message will only be read in here when the test never finishes because of infinite recursion)")
+}
+
 func TestInvokeNamed(t *testing.T) {
 	is := assert.New(t)
 

--- a/injector.go
+++ b/injector.go
@@ -26,6 +26,7 @@ func New() *Injector {
 type InjectorOpts struct {
 	HookAfterRegistration func(injector *Injector, serviceName string)
 	HookAfterShutdown     func(injector *Injector, serviceName string)
+	UseFQSN               bool // Use Fully Qualified Service Name (FQSN) for service names
 
 	Logf func(format string, args ...any)
 }
@@ -47,6 +48,7 @@ func NewWithOpts(opts *InjectorOpts) *Injector {
 
 		hookAfterRegistration: opts.HookAfterRegistration,
 		hookAfterShutdown:     opts.HookAfterShutdown,
+		useFQSN:               opts.UseFQSN,
 
 		logf: logf,
 	}
@@ -62,6 +64,7 @@ type Injector struct {
 
 	hookAfterRegistration func(injector *Injector, serviceName string)
 	hookAfterShutdown     func(injector *Injector, serviceName string)
+	useFQSN               bool // Use Fully Qualified Service Name (FQSN) for service names
 
 	logf func(format string, args ...any)
 }

--- a/injector.go
+++ b/injector.go
@@ -81,8 +81,19 @@ func (i *Injector) ListProvidedServices() []string {
 
 func (i *Injector) ListInvokedServices() []string {
 	i.mu.RLock()
-	names := keys(i.orderedInvocation)
+	invocations := invertMap(i.orderedInvocation)
+	invocationIndex := i.orderedInvocationIndex
 	i.mu.RUnlock()
+
+	names := make([]string, 0, invocationIndex+1)
+	for index := 0; index <= invocationIndex; index++ {
+		name, ok := invocations[index]
+		if !ok {
+			continue
+		}
+
+		names = append(names, name)
+	}
 
 	i.logf("exported list of invoked services: %v", names)
 

--- a/injector_test.go
+++ b/injector_test.go
@@ -45,18 +45,43 @@ func TestInjectorNewWithOpts(t *testing.T) {
 }
 
 func TestInjectorListProvidedServices(t *testing.T) {
+	type test struct{}
+
 	is := assert.New(t)
 
 	i := New()
 
 	is.NotPanics(func() {
-		ProvideValue[int](i, 42)
-		ProvideValue[float64](i, 21)
+		ProvideValue(i, 42)
+		ProvideValue(i, 21.0)
+		ProvideValue(i, test{})
 	})
 
 	is.NotPanics(func() {
 		services := i.ListProvidedServices()
-		is.ElementsMatch([]string{"int", "float64"}, services)
+		is.ElementsMatch([]string{"int", "float64", "do.test"}, services)
+	})
+}
+
+
+func TestInjectorListProvidedServicesWithFQSN(t *testing.T) {
+	type test struct{}
+	is := assert.New(t)
+
+	i := NewWithOpts(&InjectorOpts{
+		UseFQSN: true,
+	})
+
+	is.NotPanics(func() {
+		ProvideValue(i, 42)
+		ProvideValue(i, 21.0)
+		ProvideValue(i, "test")
+		ProvideValue(i, test{})
+	})
+
+	is.NotPanics(func() {
+		services := i.ListProvidedServices()
+		is.ElementsMatch([]string{"int", "float64", "string", "github.com/samber/do.test"}, services)
 	})
 }
 
@@ -66,14 +91,40 @@ func TestInjectorListInvokedServices(t *testing.T) {
 	i := New()
 
 	is.NotPanics(func() {
-		ProvideValue[int](i, 42)
-		ProvideValue[float64](i, 21)
+		ProvideValue(i, 42)
+		ProvideValue(i, 21.0)
 		MustInvoke[int](i)
 	})
 
 	is.NotPanics(func() {
 		services := i.ListInvokedServices()
 		is.Equal([]string{"int"}, services)
+	})
+}
+
+func TestInjectorListInvokedServicesWithFQSN(t *testing.T) {
+	type test struct{}
+	is := assert.New(t)
+
+	i := NewWithOpts(&InjectorOpts{
+		UseFQSN: true,
+	})
+
+	is.NotPanics(func() {
+		ProvideValue(i, 42)
+		ProvideValue(i, 21.0)
+		ProvideValue(i, "test")
+		ProvideValue(i, test{})
+
+		MustInvoke[int](i)
+		MustInvoke[float64](i)
+		MustInvoke[string](i)
+		MustInvoke[test](i)
+	})
+
+	is.NotPanics(func() {
+		services := i.ListInvokedServices()
+		is.Equal([]string{"int", "float64", "string", "github.com/samber/do.test"}, services)
 	})
 }
 
@@ -90,7 +141,7 @@ func TestInjectorHealthCheck(t *testing.T) {
 	i := New()
 
 	is.NotPanics(func() {
-		ProvideValue[int](i, 42)
+		ProvideValue(i, 42)
 		ProvideNamed(i, "testHealthCheck", func(i *Injector) (*testHealthCheck, error) {
 			return &testHealthCheck{}, nil
 		})

--- a/service.go
+++ b/service.go
@@ -68,12 +68,14 @@ func generateServiceNameWithFQSN[T any]() string {
 		return ""
 	}
 
-	name := typ.PkgPath() + "." + typ.Name()
-	if name != "" {
-		return name
+	prefix := ""
+	typName := typ
+	if typ.Kind() == reflect.Ptr {
+		prefix = "*"
+		typName = typ.Elem()
 	}
 
-	return reflect.TypeOf(new(T)).String()
+	return prefix + typName.PkgPath() + "." + typName.Name()
 }
 
 type Healthcheckable interface {

--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package do
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -10,6 +11,7 @@ type Service[T any] interface {
 	getInstance(*Injector) (T, error)
 	healthcheck() error
 	shutdown() error
+	shutdownWithContext(context.Context) error
 	clone() any
 }
 
@@ -19,6 +21,10 @@ type healthcheckableService interface {
 
 type shutdownableService interface {
 	shutdown() error
+}
+
+type shutdownableWithContextService interface {
+	shutdownWithContext(context.Context) error
 }
 
 func generateServiceNameFromInjector[T any](i *Injector) string {
@@ -91,6 +97,10 @@ type Healthcheckable interface {
 
 type Shutdownable interface {
 	Shutdown() error
+}
+
+type ShutdownableWithContext interface {
+	Shutdown(context.Context) error
 }
 
 type cloneableService interface {

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package do
 
 import (
 	"fmt"
+	"reflect"
 )
 
 type Service[T any] interface {
@@ -21,6 +22,11 @@ type shutdownableService interface {
 }
 
 func generateServiceName[T any]() string {
+	return generateServiceNameWithReflect[T]()
+}
+
+//nolint:unused
+func generateServiceNameWithSprintf[T any]() string {
 	var t T
 
 	// struct
@@ -29,9 +35,44 @@ func generateServiceName[T any]() string {
 		return name
 	}
 
-	// interface
+	//interface
 	return fmt.Sprintf("%T", new(T))
 }
+
+
+func generateServiceNameWithReflect[T any]() string {
+	var t T
+	// For non-pointer types, reflect.TypeOf(t) will never be nil.
+	// For pointer types, reflect.TypeOf(t) can be nil if t is nil.
+	typ := reflect.TypeOf(t)
+	if typ == nil {
+		return ""
+	}
+
+	if name := typ.String(); name != "" {
+		return name
+	}
+
+	return reflect.TypeOf(new(T)).String()
+}
+
+// func generateServiceName[T any]() string {
+// 	var t T
+// 	// For non-pointer types, reflect.TypeOf(t) will never be nil.
+// 	// For pointer types, reflect.TypeOf(t) can be nil if t is nil.
+// 	typ := reflect.TypeOf(t)
+// 	if typ == nil {
+// 		return ""
+// 	}
+//
+// 	name := typ.Name()
+// 	if name != "" {
+// 		return name
+// 	}
+//
+// 	return reflect.TypeOf(new(T)).Name()
+// }
+
 
 type Healthcheckable interface {
 	HealthCheck() error

--- a/service.go
+++ b/service.go
@@ -39,7 +39,6 @@ func generateServiceNameWithSprintf[T any]() string {
 	return fmt.Sprintf("%T", new(T))
 }
 
-
 func generateServiceNameWithReflect[T any]() string {
 	var t T
 	// For non-pointer types, reflect.TypeOf(t) will never be nil.
@@ -56,23 +55,26 @@ func generateServiceNameWithReflect[T any]() string {
 	return reflect.TypeOf(new(T)).String()
 }
 
-// func generateServiceName[T any]() string {
-// 	var t T
-// 	// For non-pointer types, reflect.TypeOf(t) will never be nil.
-// 	// For pointer types, reflect.TypeOf(t) can be nil if t is nil.
-// 	typ := reflect.TypeOf(t)
-// 	if typ == nil {
-// 		return ""
-// 	}
-//
-// 	name := typ.Name()
-// 	if name != "" {
-// 		return name
-// 	}
-//
-// 	return reflect.TypeOf(new(T)).Name()
-// }
+// generateServiceNameWithFQSN generates a fully qualified service name.
+// It uses the package path and type name to create a unique identifier for the service.
+// This is useful for services that are defined in different packages but have the same type name.
+// Example: "github.com/user/project/service.MyService"
+func generateServiceNameWithFQSN[T any]() string {
+	var t T
+	// For non-pointer types, reflect.TypeOf(t) will never be nil.
+	// For pointer types, reflect.TypeOf(t) can be nil if t is nil.
+	typ := reflect.TypeOf(t)
+	if typ == nil {
+		return ""
+	}
 
+	name := typ.PkgPath() + "." + typ.Name()
+	if name != "" {
+		return name
+	}
+
+	return reflect.TypeOf(new(T)).String()
+}
 
 type Healthcheckable interface {
 	HealthCheck() error

--- a/service_eager.go
+++ b/service_eager.go
@@ -1,5 +1,7 @@
 package do
 
+import "context"
+
 type ServiceEager[T any] struct {
 	name     string
 	instance T
@@ -39,6 +41,17 @@ func (s *ServiceEager[T]) shutdown() error {
 
 	return nil
 }
+
+
+func (s *ServiceEager[T]) shutdownWithContext(ctx context.Context) error {
+	instance, ok := any(s.instance).(ShutdownableWithContext)
+	if ok {
+		return instance.Shutdown(ctx)
+	}
+
+	return nil
+}
+
 
 func (s *ServiceEager[T]) clone() any {
 	return s

--- a/service_lazy.go
+++ b/service_lazy.go
@@ -1,6 +1,7 @@
 package do
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -33,7 +34,7 @@ func (s *ServiceLazy[T]) getName() string {
 
 func (s *ServiceLazy[T]) getInstance(i *Injector) (T, error) {
 	if s.building.Load() {
-		panic("DI: circular dependency detected for service " + s.name)
+		panic(fmt.Sprintf("DI: circular dependency detected for service %q", s.name))
 	}
 
 	s.mu.Lock()

--- a/service_lazy.go
+++ b/service_lazy.go
@@ -1,6 +1,7 @@
 package do
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -111,6 +112,25 @@ func (s *ServiceLazy[T]) shutdown() error {
 
 	s.built = false
 	s.instance = empty[T]()
+
+	return nil
+}
+
+func (s *ServiceLazy[T]) shutdownWithContext(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.built {
+		return nil
+	}
+
+	instance, ok := any(s.instance).(ShutdownableWithContext)
+	if ok {
+		return instance.Shutdown(ctx)
+	}
+	s.built = false
+	s.instance = empty[T]()
+
 
 	return nil
 }

--- a/service_test.go
+++ b/service_test.go
@@ -36,6 +36,15 @@ func TestGenerateServiceName(t *testing.T) {
 
 	name = generateServiceName[*int]()
 	is.Equal("*int", name)
+
+	name = generateServiceName[[]int]()
+	is.Equal("[]int", name)
+
+	name = generateServiceName[map[string]string]()
+	is.Equal("map[string]string", name)
+
+	name = generateServiceName[map[string]test]()
+	is.Equal("map[string]do.test", name)
 }
 
 func TestGenerateServiceNameWithFQSN(t *testing.T) {
@@ -68,4 +77,10 @@ func TestGenerateServiceNameWithFQSN(t *testing.T) {
 
 	name = generateServiceNameWithFQSN[*int]()
 	is.Equal("*int", name)
+
+	name = generateServiceNameWithFQSN[[]int]()
+	is.Equal("[]int", name)
+
+	name = generateServiceNameWithFQSN[map[string]string]()
+	is.Equal("map[string]string", name)
 }

--- a/service_test.go
+++ b/service_test.go
@@ -10,7 +10,9 @@ func TestGenerateServiceName(t *testing.T) {
 	is := assert.New(t)
 
 	type MyFunc func(int) int
-	type itest interface {}
+	type itest interface {
+		Do()
+	}
 	type test struct{}
 
 	name := generateServiceName[test]()
@@ -28,6 +30,9 @@ func TestGenerateServiceName(t *testing.T) {
 	name = generateServiceName[func(int)int]()
 	is.Equal("func(int) int", name)
 
+	name = generateServiceName[func(test)int]()
+	is.Equal("func(do.test) int", name)
+
 	name = generateServiceName[MyFunc]()
 	is.Equal("do.MyFunc", name)
 
@@ -40,6 +45,9 @@ func TestGenerateServiceName(t *testing.T) {
 	name = generateServiceName[[]int]()
 	is.Equal("[]int", name)
 
+	name = generateServiceName[[]test]()
+	is.Equal("[]do.test", name)
+
 	name = generateServiceName[map[string]string]()
 	is.Equal("map[string]string", name)
 
@@ -51,7 +59,9 @@ func TestGenerateServiceNameWithFQSN(t *testing.T) {
 	is := assert.New(t)
 
 	type MyFunc func(int) int
-	type itest interface {}
+	type itest interface {
+		Do()
+	}
 	type test struct{}
 
 	name := generateServiceNameWithFQSN[test]()
@@ -69,6 +79,10 @@ func TestGenerateServiceNameWithFQSN(t *testing.T) {
 	name = generateServiceNameWithFQSN[func(int)int]()
 	is.Equal("func(int) int", name)
 
+	// funcs with custom types cost too much to generate FQSN (recursion), using type aliases should be recommended
+	name = generateServiceNameWithFQSN[func(test)int]()
+	is.Equal("func(do.test) int", name)
+
 	name = generateServiceNameWithFQSN[MyFunc]()
 	is.Equal("github.com/samber/do.MyFunc", name)
 
@@ -81,6 +95,14 @@ func TestGenerateServiceNameWithFQSN(t *testing.T) {
 	name = generateServiceNameWithFQSN[[]int]()
 	is.Equal("[]int", name)
 
+	// slices with custom types cost too much to generate FQSN (recursion), using type aliases should be recommended
+	name = generateServiceNameWithFQSN[[]test]()
+	is.Equal("[]do.test", name)
+
 	name = generateServiceNameWithFQSN[map[string]string]()
 	is.Equal("map[string]string", name)
+
+	// maps with custom types cost too much to generate FQSN (recursion), using type aliases should be recommended
+	name = generateServiceNameWithFQSN[map[string]test]()
+	is.Equal("map[string]do.test", name)
 }

--- a/service_test.go
+++ b/service_test.go
@@ -9,7 +9,9 @@ import (
 func TestGenerateServiceName(t *testing.T) {
 	is := assert.New(t)
 
-	type test struct{} //nolint:unused
+	type MyFunc func(int) int
+	type itest interface {}
+	type test struct{}
 
 	name := generateServiceName[test]()
 	is.Equal("do.test", name)
@@ -17,6 +19,53 @@ func TestGenerateServiceName(t *testing.T) {
 	name = generateServiceName[*test]()
 	is.Equal("*do.test", name)
 
+	name = generateServiceName[itest]()
+	is.Equal("do.itest", name)
+
+	name = generateServiceName[*itest]()
+	is.Equal("*do.itest", name)
+
+	name = generateServiceName[func(int)int]()
+	is.Equal("func(int) int", name)
+
+	name = generateServiceName[MyFunc]()
+	is.Equal("do.MyFunc", name)
+
 	name = generateServiceName[int]()
 	is.Equal("int", name)
+
+	name = generateServiceName[*int]()
+	is.Equal("*int", name)
+}
+
+func TestGenerateServiceNameWithFQSN(t *testing.T) {
+	is := assert.New(t)
+
+	type MyFunc func(int) int
+	type itest interface {}
+	type test struct{}
+
+	name := generateServiceNameWithFQSN[test]()
+	is.Equal("github.com/samber/do.test", name)
+
+	name = generateServiceNameWithFQSN[*test]()
+	is.Equal("*github.com/samber/do.test", name)
+
+	name = generateServiceNameWithFQSN[itest]()
+	is.Equal("github.com/samber/do.itest", name)
+
+	name = generateServiceNameWithFQSN[*itest]()
+	is.Equal("*github.com/samber/do.itest", name)
+
+	name = generateServiceNameWithFQSN[func(int)int]()
+	is.Equal("func(int) int", name)
+
+	name = generateServiceNameWithFQSN[MyFunc]()
+	is.Equal("github.com/samber/do.MyFunc", name)
+
+	name = generateServiceNameWithFQSN[int]()
+	is.Equal("int", name)
+
+	name = generateServiceNameWithFQSN[*int]()
+	is.Equal("*int", name)
 }

--- a/utils.go
+++ b/utils.go
@@ -31,7 +31,7 @@ func mAp[T any, R any](collection []T, iteratee func(T) R) []R {
 }
 
 func invertMap[K comparable, V comparable](in map[K]V) map[V]K {
-	out := map[V]K{}
+	out := make(map[V]K, len(in))
 
 	for k, v := range in {
 		out[v] = k

--- a/utils.go
+++ b/utils.go
@@ -11,23 +11,23 @@ func must(err error) {
 }
 
 func keys[K comparable, V any](in map[K]V) []K {
-	result := make([]K, 0, len(in))
+	out := make([]K, 0, len(in))
 
 	for k := range in {
-		result = append(result, k)
+		out = append(out, k)
 	}
 
-	return result
+	return out
 }
 
-func mAp[T any, R any](collection []T, iteratee func(T) R) []R {
-	result := make([]R, len(collection))
+func mAp[T any, R any](in []T, f func(T) R) []R {
+	out := make([]R, len(in))
 
-	for i, item := range collection {
-		result[i] = iteratee(item)
+	for i, item := range in {
+		out[i] = f(item)
 	}
 
-	return result
+	return out
 }
 
 func invertMap[K comparable, V comparable](in map[K]V) map[V]K {


### PR DESCRIPTION
I tried to do some improvements that were implemented in v2 in v1. I made those that I believe don't need a major version bump. Here's a list of my changes:
- Detect circular dependencies.
- Use the reflect package directly instead of fmt.Sprintf("%T") to avoid parsing code for generating service names.
- ShutdownContext in the injector calls ShutdownContext on services that implement it.
- Use Fully Qualified Service Names if a flag is set to true to maintain old behavior but be able to opt in to the safe one.
- Change the ListInvokedServices method to return always the same list, previously it was iterating a map. Thus the order was random every time (tests weren't showing this because they iterate over a very little list).

I am opening this more as a point of discussion rather than seeking it to be merged. I believe these points can be achieved without a v2 version bump, allowing users to get features without package migrations.

If any of these seem interesting to actually be merged I can split them up in different non draft PRs for you to make it easier to review and merge.

Let me know what you think.

Thanks for the hard work you put into this library.