### PR TITLE
feat: add Delete method to remove scopes

### DIFF
--- a/injector.go
+++ b/injector.go
@@ -57,6 +57,12 @@ type Injector interface {
 	// ShutdownWithContext gracefully shuts down the injector and all its descendant scopes with context support.
 	ShutdownWithContext(context.Context) *ShutdownReport
 
+	// Delete gracefully shuts down the injector scope and removes it from its parent when applicable.
+	Delete() *ShutdownReport
+
+	// DeleteWithContext gracefully shuts down the injector scope with context support and removes it from its parent when applicable.
+	DeleteWithContext(context.Context) *ShutdownReport
+
 	// clone creates a deep copy of the injector with all its services and child scopes.
 	clone(*RootScope, *Scope) *Scope
 

--- a/root_scope.go
+++ b/root_scope.go
@@ -184,6 +184,23 @@ func (s *RootScope) ShutdownWithContext(ctx context.Context) *ShutdownReport {
 	return s.self.ShutdownWithContext(ctx)
 }
 
+// Delete gracefully shuts down the root scope and removes it from the hierarchy.
+// Since the root scope has no parent, this behaves like Shutdown.
+func (s *RootScope) Delete() *ShutdownReport { return s.DeleteWithContext(context.Background()) }
+
+// DeleteWithContext gracefully shuts down the root scope with context support and removes it from the hierarchy.
+// This is equivalent to ShutdownWithContext but keeps API parity with Scope.
+func (s *RootScope) DeleteWithContext(ctx context.Context) *ShutdownReport {
+	defer func() {
+		if s.healthCheckPool != nil {
+			s.healthCheckPool.stop()
+			s.healthCheckPool = nil
+		}
+	}()
+
+	return s.self.DeleteWithContext(ctx)
+}
+
 func (s *RootScope) clone(root *RootScope, parent *Scope) *Scope      { return s.self.clone(root, parent) }
 func (s *RootScope) serviceExist(name string) bool                    { return s.self.serviceExist(name) }
 func (s *RootScope) serviceExistRec(name string) bool                 { return s.self.serviceExistRec(name) }

--- a/virtual_scope.go
+++ b/virtual_scope.go
@@ -63,6 +63,10 @@ func (s *virtualScope) Shutdown() *ShutdownReport { return s.self.Shutdown() }
 func (s *virtualScope) ShutdownWithContext(ctx context.Context) *ShutdownReport {
 	return s.self.ShutdownWithContext(ctx)
 }
+func (s *virtualScope) Delete() *ShutdownReport { return s.self.Delete() }
+func (s *virtualScope) DeleteWithContext(ctx context.Context) *ShutdownReport {
+	return s.self.DeleteWithContext(ctx)
+}
 func (s *virtualScope) clone(r *RootScope, p *Scope) *Scope              { return s.self.clone(r, p) }
 func (s *virtualScope) serviceExist(name string) bool                    { return s.self.serviceExist(name) }
 func (s *virtualScope) serviceExistRec(name string) bool                 { return s.self.serviceExistRec(name) }


### PR DESCRIPTION
fix #139 

* Resolved an issue where Shutdown didn't essentially remove the container. Essentially, this is a memory leak. (For example, I create a request scooe every time I make a request, and when I make a lot of requests, the containers will become more and more.)
* To maintain API compatibility, here are two new APIs
```go
Delete() *ShutdownReport 
Delete(ctx context.Context) *ShutdownReport
```
Essentially it's still calling Shutdown internally, and then appending the code from the parent scope. If itself is root scope, then do nothing.
* Also add a test to verify logic