### PR TITLE
feat: add InvokeAsAll for bulk service invocation

### DIFF
--- a/di.go
+++ b/di.go
@@ -588,6 +588,66 @@ func MustInvokeAs[T any](i Injector) T {
 	return must1(InvokeAs[T](i))
 }
 
+// InvokeAsAll invokes all services in the DI container that match the provided type or interface.
+// This function searches through all registered services to find all that can be cast to the requested type T.
+// Returns a slice of all matching services in deterministic order by service name.
+//
+// Parameters:
+//   - i: The injector to search for services
+//
+// Returns a slice of service instances and any error that occurred during invocation.
+// If no services match, returns an empty slice and no error.
+// If some services fail to invoke, returns successfully invoked services with an error describing the failures.
+//
+// Play: https://go.dev/play/p/spRqDOsXQLs
+//
+// Example:
+//
+//	// Register multiple database implementations
+//	do.Provide(injector, func(i do.Injector) (*PostgresDB, error) {
+//	    return &PostgresDB{}, nil
+//	})
+//	do.Provide(injector, func(i do.Injector) (*MySQLDB, error) {
+//	    return &MySQLDB{}, nil
+//	})
+//	// Both implement Database interface
+//
+//	// Invoke all databases
+//	databases, err := do.InvokeAsAll[Database](injector)
+//	// databases contains both PostgresDB and MySQLDB instances
+func InvokeAsAll[T any](i Injector) ([]T, error) {
+	return invokeAsAllByGenericType[T](i)
+}
+
+// MustInvokeAsAll invokes all services in the DI container that match the provided type or interface.
+// This function panics if an error occurs during invocation.
+// Returns a slice of all matching service instances in deterministic order.
+//
+// Parameters:
+//   - i: The injector to search for services
+//
+// Returns a slice of service instances.
+// Panics if any service cannot be found or invoked.
+//
+// Play: https://go.dev/play/p/spRqDOsXQLs
+//
+// Example:
+//
+//	// Register multiple repositories
+//	do.Provide(injector, func(i do.Injector) (*UserRepository, error) {
+//	    return &UserRepository{}, nil
+//	})
+//	do.Provide(injector, func(i do.Injector) (*ProductRepository, error) {
+//	    return &ProductRepository{}, nil
+//	})
+//	// Both implement Repository interface
+//
+//	// Invoke all repositories (panics on error)
+//	repositories := do.MustInvokeAsAll[Repository](injector)
+func MustInvokeAsAll[T any](i Injector) []T {
+	return must1(InvokeAsAll[T](i))
+}
+
 /////////////////////////////////////////////////////////////////////////////
 // 							Package-level declaration
 /////////////////////////////////////////////////////////////////////////////

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -115,3 +115,7 @@ An alternative name given to a service in DI. It allows a service to be accessed
 
 A mechanism that groups multiple service registrations into a single unit that can be imported and registered with a DI container. Package loaders use `do.Package()` to assemble services with different loading strategies (lazy, eager, transient) and can include named services and interface bindings. This allows for modular service organization where related services can be bundled together and imported as a cohesive unit, promoting modularity and reusability across different parts of an application.
 
+## Bulk Service Invocation
+
+A technique for retrieving all services that implement a specific interface, returning them as a slice rather than a single instance. This is useful when you need to work with multiple implementations of the same interface, such as multiple database connections, message queue processors, or storage backends.
+

--- a/examples/invoke-as-all/example.go
+++ b/examples/invoke-as-all/example.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/samber/do/v2"
+)
+
+// Database interface
+type Database interface {
+	Name() string
+}
+
+// PostgresDB implementation
+type PostgresDB struct{}
+
+func (p *PostgresDB) Name() string { return "postgres" }
+
+// MySQLDB implementation
+type MySQLDB struct{}
+
+func (m *MySQLDB) Name() string { return "mysql" }
+
+func main() {
+	injector := do.New()
+
+	// Register multiple database implementations
+	do.Provide(injector, func(i do.Injector) (*PostgresDB, error) {
+		return &PostgresDB{}, nil
+	})
+	do.Provide(injector, func(i do.Injector) (*MySQLDB, error) {
+		return &MySQLDB{}, nil
+	})
+
+	// Invoke all databases
+	databases, err := do.InvokeAsAll[Database](injector)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Found %d databases:\n", len(databases))
+	for _, db := range databases {
+		fmt.Printf("- %s\n", db.Name())
+	}
+	// Output:
+	// Found 2 databases:
+	// - mysql
+	// - postgres
+}


### PR DESCRIPTION
Added `InvokeAsAll` and `MustInvokeAsAll` functions to enable bulk service invocation - retrieving all services that implement a specific interface as a slice.

I added both godoc as well as regular docs, but open to any changes to them.

It has deterministic ordering by service name for consistency. 

One change that can be discussed: if no services match the invocation, then an empty list is returned instead of an error/panic. I consider it a valid case that no services might match.

Relates to #114, #33 and #29