### PR TITLE
perf(stacktrace): hoist runtime.GOROOT() out of NewFrameFromCaller loop

### DIFF
--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -19,6 +19,11 @@ var (
 	packageName           = "do"
 	packageNameStacktrace = packageName + "/stacktrace/"
 	packageNameExamples   = packageName + "/examples/"
+
+	// goroot is read once at package init: runtime.GOROOT() re-reads an
+	// env var on every call, and it cannot change during the process lifetime.
+	//nolint:staticcheck
+	goroot = runtime.GOROOT()
 )
 
 // NewFrameFromCaller creates a new Frame from the current call stack.
@@ -51,8 +56,7 @@ func NewFrameFromCaller() (Frame, bool) {
 		}
 		function := shortFuncName(f.Name())
 
-		//nolint:staticcheck
-		isGoPkg := strings.Contains(file, runtime.GOROOT())                // skip frames in GOROOT
+		isGoPkg := strings.Contains(file, goroot)                          // skip frames in GOROOT
 		isDoPkg := strings.Contains(file, packageName)                     // skip frames in this package
 		isDoStacktracePkg := strings.Contains(file, packageNameStacktrace) // skip frames in this package
 		isExamplePkg := strings.Contains(


### PR DESCRIPTION
## Summary
- `runtime.GOROOT()` re-reads an environment variable on every call; it was being called on every iteration of the frame-filtering loop in `NewFrameFromCaller`. Moved it to a package-level var computed once at init, since GOROOT cannot change during a process's lifetime.
- A batched `runtime.Callers()` + `runtime.CallersFrames()` rewrite (replacing the per-frame `runtime.Caller` loop, mirroring samber/oops#108) was also tried, but measured ~45% slower and reverted: `NewFrameFromCaller` exits as soon as it finds the first non-`do`-package frame (typically within 1-2 iterations), so pre-capturing a fixed batch of frames upfront walks further into the stack than the early-exit loop actually needs.

## Benchmark
```
goos: darwin / goarch: arm64 / cpu: Apple M3
                     │   before    │            after             │
                     │   sec/op    │   sec/op     vs base          │
NewFrameFromCaller-8   442.3n ± 2%   425.8n ± 1%  -3.75% (p=0.000 n=16)

                     │  before   │           after            │
                     │   B/op    │   B/op     vs base         │
NewFrameFromCaller-8   272.0 ± 0%   272.0 ± 0%  ~ (p=1.000 n=16)
```

Verified with `go test ./stacktrace/...`, `golangci-lint run ./stacktrace/...`, and interleaved before/after benchmark runs to rule out system noise.
