### PR TITLE
perf(stacktrace): cache GOPATH split/sort in removeGoPath

### DIFF
--- a/stacktrace/stacktrace_cleanpath.go
+++ b/stacktrace/stacktrace_cleanpath.go
@@ -11,40 +11,17 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 )
 
-// goPathCacheKey/goPathCacheVal cache the split and sorted $GOPATH directory
-// list, keyed on the raw $GOPATH string: GOPATH does not change during a
-// real process's lifetime, so re-reading, re-splitting, and re-sorting it on
-// every call to removeGoPath is wasted work. The cache is keyed (rather than
-// computed once with sync.Once) because tests exercise removeGoPath against
-// several GOPATH values via os.Setenv within the same process.
-var (
-	goPathCacheMu  sync.Mutex
-	goPathCacheKey string
-	goPathCacheVal []string
-)
-
-func sortedGoPathDirs() []string {
-	current := os.Getenv("GOPATH")
-
-	goPathCacheMu.Lock()
-	defer goPathCacheMu.Unlock()
-
-	if goPathCacheVal != nil && current == goPathCacheKey {
-		return goPathCacheVal
-	}
-
-	dirs := filepath.SplitList(current)
+// goPathDirs is computed once at package init: GOPATH does not change during
+// a process's lifetime, so re-reading, re-splitting, and re-sorting it on
+// every call to removeGoPath is wasted work.
+var goPathDirs = func() []string {
+	dirs := filepath.SplitList(os.Getenv("GOPATH"))
 	// Sort in decreasing order by length so the longest matching prefix is removed
 	sort.Stable(longestFirst(dirs))
-
-	goPathCacheKey = current
-	goPathCacheVal = dirs
-
 	return dirs
-}
+}()
 
 // removeGoPath makes a path relative to one of the src directories in the $GOPATH
 // environment variable. This function is used to clean up file paths in stack traces
@@ -56,12 +33,6 @@ func sortedGoPathDirs() []string {
 // Returns the cleaned path relative to GOPATH, or the original path if it's not
 // within GOPATH or if GOPATH is empty.
 //
-// The function:
-//   - Splits GOPATH into individual directories
-//   - Sorts directories by length (longest first) to find the best match
-//   - Makes the path relative to the longest matching GOPATH/src directory
-//   - Returns the original path if no match is found
-//
 // This function is used internally by the stacktrace package to provide
 // cleaner, more readable file paths in debugging output.
 //
@@ -71,7 +42,18 @@ func sortedGoPathDirs() []string {
 //	GOPATH: "/home/user/go"
 //	Output: "github.com/user/project/main.go"
 func removeGoPath(path string) string {
-	for _, dir := range sortedGoPathDirs() {
+	return removeGoPathDirs(path, goPathDirs)
+}
+
+// removeGoPathDirs holds the matching logic, parameterized on the GOPATH
+// directory list, so it can be tested against arbitrary directories without
+// touching the process-wide GOPATH env var.
+//
+// The function:
+//   - Makes the path relative to the longest matching dir/src directory
+//   - Returns the original path if no match is found
+func removeGoPathDirs(path string, dirs []string) string {
+	for _, dir := range dirs {
 		srcdir := filepath.Join(dir, "src")
 		rel, err := filepath.Rel(srcdir, path)
 		// filepath.Rel can traverse parent directories, don't want those

--- a/stacktrace/stacktrace_cleanpath.go
+++ b/stacktrace/stacktrace_cleanpath.go
@@ -11,7 +11,40 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
+
+// goPathCacheKey/goPathCacheVal cache the split and sorted $GOPATH directory
+// list, keyed on the raw $GOPATH string: GOPATH does not change during a
+// real process's lifetime, so re-reading, re-splitting, and re-sorting it on
+// every call to removeGoPath is wasted work. The cache is keyed (rather than
+// computed once with sync.Once) because tests exercise removeGoPath against
+// several GOPATH values via os.Setenv within the same process.
+var (
+	goPathCacheMu  sync.Mutex
+	goPathCacheKey string
+	goPathCacheVal []string
+)
+
+func sortedGoPathDirs() []string {
+	current := os.Getenv("GOPATH")
+
+	goPathCacheMu.Lock()
+	defer goPathCacheMu.Unlock()
+
+	if goPathCacheVal != nil && current == goPathCacheKey {
+		return goPathCacheVal
+	}
+
+	dirs := filepath.SplitList(current)
+	// Sort in decreasing order by length so the longest matching prefix is removed
+	sort.Stable(longestFirst(dirs))
+
+	goPathCacheKey = current
+	goPathCacheVal = dirs
+
+	return dirs
+}
 
 // removeGoPath makes a path relative to one of the src directories in the $GOPATH
 // environment variable. This function is used to clean up file paths in stack traces
@@ -38,10 +71,7 @@ import (
 //	GOPATH: "/home/user/go"
 //	Output: "github.com/user/project/main.go"
 func removeGoPath(path string) string {
-	dirs := filepath.SplitList(os.Getenv("GOPATH"))
-	// Sort in decreasing order by length so the longest matching prefix is removed
-	sort.Stable(longestFirst(dirs))
-	for _, dir := range dirs {
+	for _, dir := range sortedGoPathDirs() {
 		srcdir := filepath.Join(dir, "src")
 		rel, err := filepath.Rel(srcdir, path)
 		// filepath.Rel can traverse parent directories, don't want those

--- a/stacktrace/stacktrace_cleanpath_test.go
+++ b/stacktrace/stacktrace_cleanpath_test.go
@@ -7,9 +7,7 @@ package stacktrace
 ///
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,11 +52,11 @@ func TestRemoveGoPath(t *testing.T) {
 			expected: "pkg/prog.go",
 		},
 	} {
-		gopath := strings.Join(testcase.gopath, string(filepath.ListSeparator))
-		err := os.Setenv("GOPATH", gopath)
-		assert.NoError(t, err, "error setting gopath")
+		dirs := make([]string, len(testcase.gopath))
+		copy(dirs, testcase.gopath)
+		sort.Stable(longestFirst(dirs))
 
-		cleaned := removeGoPath(testcase.path)
+		cleaned := removeGoPathDirs(testcase.path, dirs)
 		assert.Equal(t, testcase.expected, cleaned, "testcase: %+v", testcase)
 	}
 }


### PR DESCRIPTION
## Summary
- `removeGoPath` re-read `GOPATH`, re-split it with `filepath.SplitList`, and re-sorted the resulting directory list on every single call, even though `GOPATH` does not change during a process's lifetime.
- Cache the split/sorted directory list in a package-level var computed once at init, matching the pattern used by [samber/oops's `stacktrace_cleanpath.go`](https://github.com/samber/oops/blob/master/stacktrace_cleanpath.go).
- `TestRemoveGoPath` used to mutate `GOPATH` via `os.Setenv` across several subcases in the same test process, which is incompatible with a value computed once at init. Following oops's own test, the matching logic is split into `removeGoPathDirs(path, dirs)`, and the test now passes directory lists directly instead of touching the process-wide `GOPATH` env var.

An earlier revision of this PR used a mutex-guarded cache keyed on the raw `GOPATH` string to keep the original env-var-mutating test working. That version worked but paid for an `os.Getenv` + mutex lock/unlock on every call. Switching to the oops-style init-once var and adapting the test instead removes that overhead entirely.

## Benchmark
Full picture, from the original uncached `removeGoPath` to this PR:
```
goos: darwin / goarch: arm64 / cpu: Apple M3
                     │   before    │            after             │
                     │   sec/op    │   sec/op     vs base          │
NewFrameFromCaller-8   438.6n ± 2%   401.5n ± 0%   -8.46%
NewFrameFromPC-8       102.5n ± 3%   70.90n ± 0%  -30.83%

                     │  before   │           after             │
                     │   B/op    │   B/op     vs base          │
NewFrameFromCaller-8   272.0 ± 0%   248.0 ± 0%    -8.82%
NewFrameFromPC-8       24.00 ± 0%     0.00 ± 0%  -100.00%
```

Verified with `go test -race ./stacktrace/...`, `golangci-lint run ./stacktrace/...`, and interleaved before/after benchmark runs to rule out system noise.
