### PR TITLE
perf: build Ancestors() iteratively

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -131,9 +131,9 @@ func (s *Scope) Ancestors() []*Scope {
 	// parentScope is immutable, so the chain can be walked without locking.
 	// This reaches into the unexported parentScope field of other *Scope
 	// instances (not just s), which breaks normal encapsulation, but it lets
-	// the whole chain be walked in a single pass with one right-sized
-	// allocation instead of the O(n^2) allocations of the previous recursive,
-	// method-based traversal.
+	// the whole chain be walked iteratively with one right-sized allocation,
+	// avoiding the O(n) allocations and O(n^2) total element copies/bytes of
+	// the previous recursive, method-based traversal.
 	depth := 0
 	for p := s.parentScope; p != nil; p = p.parentScope {
 		depth++

--- a/scope.go
+++ b/scope.go
@@ -128,11 +128,18 @@ func (s *Scope) RootScope() *RootScope {
 //
 // Play: https://go.dev/play/p/e_oxd7b-q9h
 func (s *Scope) Ancestors() []*Scope {
-	if s.parentScope == nil {
-		return []*Scope{}
+	// parentScope is immutable, so the chain can be walked without locking.
+	depth := 0
+	for p := s.parentScope; p != nil; p = p.parentScope {
+		depth++
 	}
 
-	return append([]*Scope{s.parentScope}, s.parentScope.Ancestors()...)
+	ancestors := make([]*Scope, 0, depth)
+	for p := s.parentScope; p != nil; p = p.parentScope {
+		ancestors = append(ancestors, p)
+	}
+
+	return ancestors
 }
 
 // Children returns the list of immediate child scopes.

--- a/scope.go
+++ b/scope.go
@@ -139,9 +139,9 @@ func (s *Scope) Ancestors() []*Scope {
 		depth++
 	}
 
-	ancestors := make([]*Scope, 0, depth)
-	for p := s.parentScope; p != nil; p = p.parentScope {
-		ancestors = append(ancestors, p)
+	ancestors := make([]*Scope, depth)
+	for i, p := 0, s.parentScope; p != nil; i, p = i+1, p.parentScope {
+		ancestors[i] = p
 	}
 
 	return ancestors

--- a/scope.go
+++ b/scope.go
@@ -129,6 +129,11 @@ func (s *Scope) RootScope() *RootScope {
 // Play: https://go.dev/play/p/e_oxd7b-q9h
 func (s *Scope) Ancestors() []*Scope {
 	// parentScope is immutable, so the chain can be walked without locking.
+	// This reaches into the unexported parentScope field of other *Scope
+	// instances (not just s), which breaks normal encapsulation, but it lets
+	// the whole chain be walked in a single pass with one right-sized
+	// allocation instead of the O(n^2) allocations of the previous recursive,
+	// method-based traversal.
 	depth := 0
 	for p := s.parentScope; p != nil; p = p.parentScope {
 		depth++


### PR DESCRIPTION
## Summary

`Scope.Ancestors()` built its result by recursively appending to a growing slice:

```go
return append([]*Scope{s.parentScope}, s.parentScope.Ancestors()...)
```

Each level of recursion allocates a fresh single-element slice and then reallocates/copies to append the rest of the chain — O(n) allocations and O(n²) element copies for a chain of `n` ancestors.

This PR walks the immutable `parentScope` chain iteratively instead: once to count the depth, once to fill a right-sized slice. Ordering (immediate parent to root) and the empty-slice behavior for the root scope are unchanged.

## Benchmark

`benchstat`, count=10, benchtime=500ms, darwin/arm64 (Apple M3), 10-deep scope chain (`BenchmarkAncestors` in `bench/do_bench_test.go`):

```
            │   old.txt    │               new.txt               │
            │    sec/op    │   sec/op     vs base                │
Ancestors-8   234.80n ± 2%   26.28n ± 3%  -88.81% (p=0.000 n=10)

            │   old.txt   │              new.txt               │
            │    B/op     │    B/op     vs base                │
Ancestors-8   496.00 ± 0%   80.00 ± 0%  -83.87% (p=0.000 n=10)

            │   old.txt   │              new.txt               │
            │  allocs/op  │ allocs/op   vs base                │
Ancestors-8   14.000 ± 0%   1.000 ± 0%  -92.86% (p=0.000 n=10)
```

Verified with `go test -race ./...` on the affected packages.