### PR TITLE
perf(dag): batch dependent checks per shutdown round

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -129,6 +129,26 @@ func (d *DAG) removeService(scopeID, scopeName, serviceName string) {
 	delete(d.dependents, desc)
 }
 
+// listServicesHavingNoDependent returns the subset of the provided service names
+// (all belonging to the scope identified by scopeID/scopeName) that have no
+// dependents registered in the graph. It takes a single read lock for the
+// whole batch and does not allocate per-service dependency lists, unlike
+// repeated explainService calls.
+func (d *DAG) listServicesHavingNoDependent(scopeID, scopeName string, serviceNames []string) []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	out := make([]string, 0, len(serviceNames))
+	for _, name := range serviceNames {
+		desc := newServiceDescription(scopeID, scopeName, name)
+		if len(d.dependents[desc]) == 0 {
+			out = append(out, name)
+		}
+	}
+
+	return out
+}
+
 // explainService provides information about a service's dependencies and dependents in the DAG.
 // This function returns the list of services that the specified service depends on,
 // as well as the list of services that depend on the specified service.

--- a/scope.go
+++ b/scope.go
@@ -440,20 +440,17 @@ func (s *Scope) shutdownServicesInParallel(ctx context.Context) *ShutdownReport 
 		return keys(s.services)
 	}
 
-	for len(listServices()) > 0 {
+	for {
+		// loop over the services that have not been shutdown already
 		services := listServices()
-		servicesToShutdown := []string{}
-
-		// loop over the service that have not been shutdown already
-		for _, name := range services {
-			// Check the service has no dependents (dependencies allowed here).
-			// Services having dependents must be shutdown first.
-			// The next iteration will shutdown current service.
-			_, dependents := s.rootScope.dag.explainService(s.id, s.name, name)
-			if len(dependents) == 0 {
-				servicesToShutdown = append(servicesToShutdown, name)
-			}
+		if len(services) == 0 {
+			break
 		}
+
+		// Check, under a single DAG lock, which services have no dependents
+		// (dependencies allowed here). Services having dependents must be
+		// shutdown first; the next iteration will shutdown the current service.
+		servicesToShutdown := s.rootScope.dag.listServicesHavingNoDependent(s.id, s.name, services)
 
 		if len(servicesToShutdown) > 0 {
 			r := s.shutdownServicesWithoutDependenciesInParallel(ctx, servicesToShutdown)


### PR DESCRIPTION
## Summary

Each shutdown round called `listServices()` twice and queried `dag.explainService` once per service (a DAG read lock + 2 slice allocations each, discarding the dependencies half of the result), even though only the dependent count matters. Adds `DAG.listServicesHavingNoDependent`, which filters a whole round under a single read lock and doesn't allocate per-service dependency lists, and calls `listServices()` once per round instead of twice.

Round-by-round shutdown ordering and the circular-dependency fallback (shut down all remaining services when none are dependent-free) are unchanged.

## Benchmark

`master` vs this branch, `BenchmarkShutdown` (`bench/do_bench_test.go`, 20-service dependency chain), `-benchmem -count=8`, Go 1.26, darwin/arm64, Apple M3:

```
             │    before     │             after              │
             │    sec/op     │   sec/op     vs base            │
Shutdown-8     474.5µs ± 284%   291.2µs ± 20%  -38.63% (p=0.002 n=8)

             │   before   │            after             │
             │    B/op    │    B/op     vs base          │
Shutdown-8     109.15Ki      91.04Ki   -16.60% (p=0.000 n=8)
             │ allocs/op  │  allocs/op   vs base         │
Shutdown-8     945.0         546.0     -42.22% (p=0.000 n=8)
```

Timing spread is wide because the host was under heavy background load during this run; allocation counts are deterministic and confirm the win regardless.

Verified with `go build ./...`, `go test -race ./...`, and `golangci-lint run ./...` (the 3 remaining govet findings in `di.go`/`invoke.go`/`utils.go` pre-exist on `master` and are unrelated to this change).
