### PR TITLE
docs(package-loading): add a testing and mocking example

### DIFF
--- a/docs/docs/service-registration/package-loading.md
+++ b/docs/docs/service-registration/package-loading.md
@@ -164,18 +164,17 @@ This requires each service to be exposed through an interface (see [Accept inter
   </TabItem>
   <TabItem value="test" label="pkg/auth/auth_test.go">
     ```go
-    package auth_test
+    package auth
 
     import (
         "testing"
 
-        "github.com/foo/bar/pkg/auth"
         "github.com/foo/bar/pkg/repositories"
     )
 
     func TestAuthRegister(t *testing.T) {
         injector := do.New(
-            auth.Package,
+            Package,
             repositories.PackageMock,
         )
 

--- a/docs/docs/service-registration/package-loading.md
+++ b/docs/docs/service-registration/package-loading.md
@@ -78,3 +78,117 @@ The traditional vocab can be translated for package registration:
 - `ProvideNamedTransient[T](Injector, string, Provider[T])` -> `TransientNamed(string, Provider[T])`
 - `As[Initial, Alias](Injector)` -> `Bind[Initial, Alias]()`
 - `AsNamed[Initial, Alias](Injector, string, string)` -> `BindNamed[Initial, Alias](string, string)`
+
+## Testing and mocking
+
+A package can ship a second variant, exposing test doubles behind the same interfaces as the production services. Swapping `Package` for its mock counterpart in a test injector replaces every service it registers, without touching the code under test.
+
+This requires each service to be exposed through an interface (see [Accept interfaces, return structs](../service-invocation/accept-interfaces-return-structs.md)), with both the real and the mock implementation satisfying it.
+
+<Tabs>
+  <TabItem value="repository" label="pkg/repositories/user_repository.go" default>
+    ```go
+    package repositories
+
+    type UserRepository interface {
+        FindByID(id string) (*User, error)
+    }
+
+    func newUserRepository(i do.Injector) (UserRepository, error) {
+        pool := do.MustInvoke[*pgxpool.Pool](i)
+        return &userRepository{pool: pool}, nil
+    }
+
+    type userRepository struct {
+        pool *pgxpool.Pool
+    }
+
+    func (r *userRepository) FindByID(id string) (*User, error) {
+        // query the database
+    }
+
+    var _ UserRepository = (*userRepository)(nil)
+    ```
+  </TabItem>
+  <TabItem value="mock" label="pkg/repositories/user_repository_mock.go">
+    ```go
+    package repositories
+
+    func newUserRepositoryMock(i do.Injector) (UserRepository, error) {
+        return &userRepositoryMock{users: map[string]*User{}}, nil
+    }
+
+    type userRepositoryMock struct {
+        users map[string]*User
+    }
+
+    func (r *userRepositoryMock) FindByID(id string) (*User, error) {
+        // return a fixture, or an error if absent
+    }
+
+    var _ UserRepository = (*userRepositoryMock)(nil)
+    ```
+  </TabItem>
+  <TabItem value="package" label="pkg/repositories/package.go">
+    ```go
+    package repositories
+
+    var Package = do.Package(
+        do.Lazy(newPostgreSQLPool),
+        do.Lazy(newUserRepository),
+        do.Lazy(newBillingRepository),
+    )
+
+    var PackageMock = do.Package(
+        do.Lazy(newUserRepositoryMock),
+        do.Lazy(newBillingRepositoryMock),
+    )
+    ```
+  </TabItem>
+  <TabItem value="main" label="cmd/main.go">
+    ```go
+    package main
+
+    import (
+        "github.com/foo/bar/pkg/auth"
+        "github.com/foo/bar/pkg/repositories"
+    )
+
+    func main() {
+        injector := do.New(
+            auth.Package,
+            repositories.Package,
+        )
+    }
+    ```
+  </TabItem>
+  <TabItem value="test" label="pkg/auth/auth_test.go">
+    ```go
+    package auth_test
+
+    import (
+        "testing"
+
+        "github.com/foo/bar/pkg/auth"
+        "github.com/foo/bar/pkg/repositories"
+    )
+
+    func TestAuthRegister(t *testing.T) {
+        injector := do.New(
+            auth.Package,
+            repositories.PackageMock,
+        )
+
+        // ...
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+**Play: https://go.dev/play/p/s-ZWLUGiMaT**
+
+:::tip
+
+Only mock the packages relevant to the test. Combining `repositories.Package` for services you don't need to fake with `repositories.PackageMock` for the one you do is a common pattern, as long as both variants don't register the same service twice in the same injector.
+
+:::

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'samber/do — Go Dependency Injection',
+  title: 'samber/do - Go Dependency Injection',
   tagline: 'Type-safe DI for Go using generics',
   favicon: 'img/favicon.ico',
 


### PR DESCRIPTION
## Summary
- Adds a "Testing and mocking" section to the Package loading doc
- Shows the `Package` / `PackageMock` pattern: same interface, prod repository swapped for a mock repository in test injectors
- Snippet verified runnable on the Go Playground
- Swaps the em dash for a plain hyphen in the website title

Written from an airport gate, late at night, boarding call for holidays any minute now -- if a typo slipped through, blame the vacation brain, not the reviewer.