### PR TITLE
fix: handle nil dependencies in InvokeStruct

### DIFF
--- a/di_test.go
+++ b/di_test.go
@@ -907,6 +907,35 @@ func TestInvokeStruct(t *testing.T) {
 	test11, err := InvokeStruct[****serviceWithInterface](i)
 	is.NoError(err)
 	is.NotNil((****test11).eagerTest) //nolint:gocritic
+
+	// assign a nil interface returned by a provider
+	i = New()
+	Provide(i, func(i Injector) (Healthchecker, error) {
+		return nil, nil
+	})
+	test12, err := InvokeStruct[serviceWithInterface](i)
+	is.NoError(err)
+	is.Nil(test12.eagerTest)
+
+	// assign a nil interface found through implicit aliasing
+	i = New()
+	Provide(i, func(i Injector) (iTestHeathchecker, error) {
+		return nil, nil
+	})
+	test13, err := InvokeStruct[serviceWithInterface](i)
+	is.NoError(err)
+	is.Nil(test13.eagerTest)
+
+	// reject a nil service whose declared type is not assignable to the field
+	type namedNilTypeMismatch struct {
+		EagerTest *eagerTest `do:"nil-healthchecker"`
+	}
+	ProvideNamed(i, "nil-healthchecker", func(i Injector) (Healthchecker, error) {
+		return nil, nil
+	})
+	test14, err := InvokeStruct[namedNilTypeMismatch](i)
+	is.Equal("DI: `nil-healthchecker` is not assignable to field `github.com/samber/do/v2.namedNilTypeMismatch.EagerTest`", err.Error())
+	is.Empty(test14)
 }
 
 func TestMustInvokeStruct(t *testing.T) {

--- a/invoke.go
+++ b/invoke.go
@@ -253,6 +253,7 @@ func invokeByTags(i Injector, structName string, structValue reflect.Value, impl
 		if serviceName == "" {
 			serviceName = typetostring.GetReflectValueType(fieldValue)
 		}
+		resolvedServiceName := serviceName
 
 		dependency, err := invokeAnyByName(injector, serviceName)
 		// @TODO: This fallback may pick an arbitrary matching service; selection order is not stable.
@@ -275,6 +276,7 @@ func invokeByTags(i Injector, structName string, structValue reflect.Value, impl
 			})
 
 			if found {
+				resolvedServiceName = resolvedName
 				dependency, err = invokeAnyByName(injector, resolvedName)
 			}
 		}
@@ -283,6 +285,15 @@ func invokeByTags(i Injector, structName string, structValue reflect.Value, impl
 		}
 
 		dependencyValue := reflect.ValueOf(dependency)
+		if !dependencyValue.IsValid() {
+			service, _, found := injector.serviceGetRec(resolvedServiceName)
+			if !found || !service.(serviceWrapperGetReflectType).getReflectType().AssignableTo(fieldValue.Type()) { //nolint:errcheck,forcetypeassert
+				return fmt.Errorf("DI: `%s` is not assignable to field `%s.%s`", serviceName, structName, field.Name)
+			}
+
+			fieldValue.Set(reflect.Zero(fieldValue.Type()))
+			continue
+		}
 
 		// Should be checked before invocation, because we just built something that is not assignable to the field.
 		if !dependencyValue.Type().AssignableTo(fieldValue.Type()) {


### PR DESCRIPTION
## Summary

Fix `InvokeStruct` panicking when a provider returns a nil interface with no error.

## Problem

Providers may legitimately return the zero value of an interface type:

```go
do.Provide(injector, func(do.Injector) (Service, error) {
    return nil, nil
})
```

Direct invocation supports this, but injecting the same service through `InvokeStruct` caused a panic:

```
reflect: call of reflect.Value.Type on zero Value
```

This happened because `reflect.ValueOf(nil)` returns an invalid `reflect.Value`, and `invokeByTags` called `Type()` on it.

## Solution

When a resolved dependency is nil:

- use the registered service's declared type to verify assignability;
- set the destination field to its zero value when the types are compatible;
- preserve the existing type-mismatch error when they are incompatible;
- use the actual resolved service name when implicit aliasing is involved.

## Tests

Added regression coverage for:

- injecting a nil interface returned by a provider;
- injecting a nil interface resolved through implicit aliasing;
- rejecting a nil dependency whose declared type is incompatible with the destination field.
